### PR TITLE
draft of records using non-null prototype, with only symbol-forwarding

### DIFF
--- a/spec/immutable-data-structures.html
+++ b/spec/immutable-data-structures.html
@@ -57,20 +57,44 @@
           <p>The parameter _iterable_ is expected to be an object that implements an @@iterator method that returns an iterator object that produces a two element array-like object whose first element is a value that will be used as a Map key and whose second element is the value to associate with that key.</p>
         </emu-note>
       </emu-clause>
-      <emu-clause id="sec-record.isrecord">
-        <h1>Record.isRecord ( _arg_ )</h1>
-        <p>The *isRecord* function takes one argument _arg_, and performs the following steps:</p>
-        <emu-alg>
-          1. If Type(_arg_) is Record, return `true`.
-          1. If Type(_arg_) is Object and _arg_ has a [[RecordData]] internal slot, return `true`.
-          1. Return `false`.
-        </emu-alg>
-      </emu-clause>
       <emu-clause id="sec-record.prototype">
         <h1>Record.prototype</h1>
-        <p>The initial value of *Record.prototype* is the value *null*.</p>
+        <p>The initial value of *Record.prototype* is %Record.prototype%.</p>
 
         <p>This property has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: false }.</p>
+      </emu-clause>
+    </emu-clause>
+    <emu-clause id="sec-properties-of-the-record-prototype-object">
+      <h1>Properties of the Record Prototype Object</h1>
+      <p>The Record prototype object:</p>
+      <ul>
+        <li>is an ordinary object.</li>
+        <li>is not a Record object; it does not have a [[RecordData]] internal slot.</li>
+        <li>has a [[Prototype]] internal slot whose value is *null*.</li>
+      </ul>
+      <p>The abstract operation <dfn id="sec-thisRecordValue" aoid="thisRecordValue">thisRecordValue</dfn> takes argument _value_. It performs the following steps when called:</p>
+      <emu-alg>
+        1. If Type(_value_) is Record, return _value_.
+        1. If Type(_value_) is Object and _value_ has a [[RecordData]] internal slot, then
+          1. Let _r_ be _value_.[[RecordData]].
+          1. Assert: Type(_r_) is Record.
+          1. Return _r_.
+        1. Throw a *TypeError* exception.
+      </emu-alg>
+      <emu-clause id="sec-record.prototype-@@toprimitive">
+        <h1>Record.prototype [ @@toPrimitive ] ( _hint_ )</h1>
+        <p>This function is called by ECMAScript language operators to convert a Record object to a primitive value. The allowed values for _hint_ are *"default"*, *"number"*, and *"string"*.</p>
+        <p>When the `@@toPrimitive` method is called with argument _hint_, the following steps are taken:</p>
+        <emu-alg>
+          1. Return ? thisRecordValue(*this* value).
+        </emu-alg>
+        <p>The value of the *"name"* property of this function is *"[Symbol.toPrimitive]"*.</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+      </emu-clause>
+      <emu-clause id="sec-record.prototype-@@toStringTag">
+        <h1>Record.prototype [ @@toStringTag ]</h1>
+        <p>The initial value of *Record.prototype[@@toStringTag]* is the String value *"Record"*.</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
   </emu-clause>

--- a/spec/ordinary-and-exotic-object-behaviours.html
+++ b/spec/ordinary-and-exotic-object-behaviours.html
@@ -13,7 +13,7 @@
       <p>An object is a <dfn id="record-exotic-object">Record exotic object</dfn> (or simply, a Record object) if its following internal methods use the following implementations and is an <emu-xref href="#sec-immutable-prototype-exotic-objects">Immutable Prototype Exotic Object</emu-xref>. These methods are installed in RecordCreate.</p>
 
       <p>Record exotic objects have the same internal slots as ordinary objects. They also have a [[RecordData]] internal slot.</p>
-      
+
       <emu-clause id="sec-record-exotic-objects-isextensible">
         <h1>[[IsExtensible]] ()</h1>
         <p>When the [[IsExtensible]] internal method of a Record exotic object _R_ is called, the following steps are taken:</p>
@@ -50,23 +50,27 @@
           1. Return *false*.
         </emu-alg>
       </emu-clause>
-      
+
       <emu-clause id="sec-record-exotic-objects-hasproperty-p">
         <h1>[[HasProperty]] ( _P_ )</h1>
         <p>When the [[HasProperty]] internal method of a Record exotic object _R_ is called with property key _P_, the following steps are taken:</p>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
-          1. If Type(_P_) is a Symbol, return *false*.
+          1. If Type(_P_) is a Symbol,
+            1. Let _parent_ be ? _R_.[[GetPrototypeOf]]().
+            1. Return ? _parent_.[[HasProperty]](_P_).
           1. Return ! RecordHasProperty(_R_, _P_).
         </emu-alg>
       </emu-clause>
-            
+
       <emu-clause id="sec-record-exotic-objects-get-p-receiver">
         <h1>[[Get]] ( _P_, _Receiver_ )</h1>
         <p>When the [[Get]] internal method of a Record exotic object _R_ is called with property key _P_ and ECMAScript language value _Receiver_, the following steps are taken:</p>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
-          1. If Type(_P_) is a Symbol, return *undefined*.
+          1. If Type(_P_) is a Symbol,
+            1. Let _parent_ be ? _R_.[[GetPrototypeOf]]().
+            1. Return ? _parent_.[[Get]](_P_, _Receiver_).
           1. Let _value_ be ! RecordGet( _R_, _P_ ).
           1. If _value_ is ~empty~, return *undefined*.
           1. Return _value_
@@ -123,7 +127,7 @@
             1. Return _R_.
         </emu-alg>
       </emu-clause>
-      
+
       <emu-clause id="sec-recordhasproperty-r-p" aoid="RecordHasProperty">
         <h1>RecordHasProperty ( _R_, _P_ )</h1>
         <p>This abstract operation RecordHasProperty takes arguments _R_ and _P_. It performs the following steps when called:</p>
@@ -138,7 +142,7 @@
           1. Return *false*.
         </emu-alg>
       </emu-clause>
-      
+
       <emu-clause id="sec-recordget-r-p" aoid="RecordGet">
         <h1>RecordGet ( _R_, _P_ )</h1>
         <p>This abstract operation RecordGet takes arguments _R_ and _P_. It performs the following steps when called:</p>
@@ -207,7 +211,7 @@
           1. Return *false*.
         </emu-alg>
       </emu-clause>
-      
+
       <emu-clause id="sec-tuple-exotic-objects-hasproperty-p">
         <h1>[[HasProperty]] ( _P_ )</h1>
         <p>When the [[HasProperty]] internal method of a Tuple exotic object _T_ is called with property key _P_, the following steps are taken:</p>
@@ -220,7 +224,7 @@
           1. Return ? _parent_.[[HasProperty]](_P_, _Receiver_).
         </emu-alg>
       </emu-clause>
-            
+
       <emu-clause id="sec-tuple-exotic-objects-get-p-receiver">
         <h1>[[Get]] ( _P_, _Receiver_ )</h1>
         <p>When the [[Get]] internal method of a Tuple exotic object _T_ is called with property key _P_ and ECMAScript language value _Receiver_, the following steps are taken:</p>
@@ -257,7 +261,7 @@
           1. Return *false*.
         </emu-alg>
       </emu-clause>
-      
+
       <emu-clause id="sec-tuple-exotic-objects-ownpropertykeys">
         <h1>[[OwnPropertyKeys]] ( )</h1>
         <p>When the [[OwnPropertyKeys]] internal method of a Record exotic object _T_ is called, the following steps are taken:</p>
@@ -274,7 +278,7 @@
         </emu-alg>
       </emu-clause>
 
-      
+
       <emu-clause id="sec-tuplecreate" aoid="TupleCreate">
         <h1>TupleCreate ( _value_ )</h1>
         <p>This abstract operation TupleCreate takes a _value_ argument. It is used to specify the creation of new Tuple exotic objects. It performs the following steps when called:</p>
@@ -288,7 +292,7 @@
             1. Return _T_.
         </emu-alg>
       </emu-clause>
-      
+
       <emu-clause id="sec-isvalidtupleindex-r-p" aoid="IsValidTupleIndex">
         <h1>IsValidTupleIndex ( _T_, _numericIndex_ )</h1>
         <p>This abstract operation IsValidTupleIndex takes arguments _T_ and _numericIndex_. It performs the following steps when called:</p>
@@ -300,7 +304,7 @@
           1. Return *true*.
         </emu-alg>
       </emu-clause>
-      
+
       <emu-clause id="sec-tupleget-r-p" aoid="TupleGet">
         <h1>TupleGet ( _T_, _numericIndex_ )</h1>
         <p>This abstract operation TupleGet takes arguments _T_ and _numericIndex_. It performs the following steps when called:</p>


### PR DESCRIPTION
In response to issue #142, this is a draft of the changes for a Record prototype who's prototype is `null` and has `Symbol.toStringTag`, `Symbol.toPrimitive` etc, and the `Record` wrapper object only forwards symbol properties to the prototype.