### PR TITLE
Write spec for JSON.parseImmutable

### DIFF
--- a/spec/structured-data.html
+++ b/spec/structured-data.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<meta charset="utf8" />
+
+<emu-clause id="sec-structured-data">
+  <h1>Structured Data</h1>
+
+  <emu-clause id="sec-json-object">
+    <h1>The JSON Object</h1>
+
+    <emu-clause id="sec-json.parse">
+      <h1>JSON.parse ( _text_ [ , _reviver_ ] )</h1>
+      <p>The `parse` function parses a JSON text (a JSON-formatted String) and produces an ECMAScript value. The JSON format represents literals, arrays, and objects with a syntax similar to the syntax for ECMAScript literals, Array Initializers, and Object Initializers. After parsing, JSON objects are realized as ECMAScript objects. JSON arrays are realized as ECMAScript Array instances. JSON strings, numbers, booleans, and null are realized as ECMAScript Strings, Numbers, Booleans, and *null*.</p>
+      <p>The optional _reviver_ parameter is a function that takes two parameters, _key_ and _value_. It can filter and transform the results. It is called with each of the _key_/_value_ pairs produced by the parse, and its return value is used instead of the original value. If it returns what it received, the structure is not modified. If it returns *undefined* then the property is deleted from the result.</p>
+      <emu-alg>
+        1. <del>Let _jsonString_ be ? ToString(_text_).</del>
+        1. <del>Parse ! UTF16DecodeString(_jsonString_) as a JSON text as specified in ECMA-404. Throw a *SyntaxError* exception if it is not a valid JSON text as defined in that specification.</del>
+        1. <del>Let _scriptString_ be the string-concatenation of *"("*, _jsonString_, and *");"*.</del>
+        1. <del>Let _completion_ be the result of parsing and evaluating ! UTF16DecodeString(_scriptString_) as if it was the source text of an ECMAScript |Script|. The extended PropertyDefinitionEvaluation semantics defined in must not be used during the evaluation.</del>
+        1. <del>Let _unfiltered_ be _completion_.[[Value]].</del>
+        1. <del>Assert: _unfiltered_ is either a String, Number, Boolean, Null, or an Object that is defined by either an |ArrayLiteral| or an |ObjectLiteral|.</del>
+        1. <ins>Let _unfiltered_ be ? ParseJSONText(_text_).</ins>
+        1. If IsCallable(_reviver_) is *true*, then
+          1. Let _root_ be OrdinaryObjectCreate(%Object.prototype%).
+          1. Let _rootName_ be the empty String.
+          1. Perform ! CreateDataPropertyOrThrow(_root_, _rootName_, _unfiltered_).
+          1. Return ? InternalizeJSONProperty(_root_, _rootName_, _reviver_).
+        1. Else,
+          1. Return _unfiltered_.
+      </emu-alg>
+      <p>This function is the <dfn>%JSONParse%</dfn> intrinsic object.</p>
+      <p>The *"length"* property of the `parse` function is 2.</p>
+  
+      <emu-clause id="sec-parsejsontext" aoid="ParseJSONText">
+        <h1><ins>Runtime Semantics: ParseJSONText ( _text_ )</ins></h1>
+        <p>The abstract operation ParseJSONText parses a JSON text (a JSON-formatted String) and produces an ECMAScript value.</p>
+        <emu-alg>
+          1. Let _jsonString_ be ? ToString(_text_).
+          1. Parse ! UTF16DecodeString(_jsonString_) as a JSON text as specified in ECMA-404. Throw a *SyntaxError* exception if it is not a valid JSON text as defined in that specification.
+          1. Let _scriptString_ be the string-concatenation of *"("*, _jsonString_, and *");"*.
+          1. Let _completion_ be the result of parsing and evaluating ! UTF16DecodeString(_scriptString_) as if it was the source text of an ECMAScript |Script|. The extended PropertyDefinitionEvaluation semantics defined in must not be used during the evaluation.
+          1. Let _unfiltered_ be _completion_.[[Value]].
+          1. Assert: _unfiltered_ is either a String, Number, Boolean, Null, or an Object that is defined by either an |ArrayLiteral| or an |ObjectLiteral|.
+          1. Return _unfiltered_.
+        </emu-alg>
+      </emu-clause>
+    </emu-clause>
+  
+    <emu-clause id="sec-json.parseimmutable">
+      <h1><ins>JSON.parseImmutable ( _text_ [ , _reviver_ ] )</ins></h1>
+      <p>The `parseImmutable` function parses a JSON text (a JSON-formatted String) and produces an ECMAScript value. The JSON format represents literals, arrays, and objects with a syntax similar to the syntax for ECMAScript literals, Array Initializers, and Object Initializers. After parsing, JSON objects are realized as ECMAScript records. JSON arrays are realized as ECMAScript tuples. JSON strings, numbers, booleans, and null are realized as ECMAScript Strings, Numbers, Booleans, and *null*.</p>
+      <p>The optional _reviver_ parameter is a function that takes two parameters, _key_ and _value_. It can filter and transform the results. It is called with each of the _key_/_value_ pairs produced by the parse, and its return value is used instead of the original value. If it returns what it received, the structure is not modified. If it returns *undefined* then the property is deleted from the result.</p>
+      <emu-alg>
+        1. Let _unfiltered_ be ? ParseJSONText(_text_).
+        1. Return ? BuildImmutableProperty(_unfiltered_, *""*, _reviver_).
+      </emu-alg>
+      <p>This function is the <dfn>%JSONParseImmutable%</dfn> intrinsic object.</p>
+      <p>The *"length"* property of the `parseImmutable` function is 2.</p>
+  
+      <emu-clause id="sec-buildimmutableproperty" aoid="BuildImmutableProperty">
+        <h1><ins>Runtime Semantics: BuildImmutableProperty ( _value_, _name_, _reviver_ )</ins></h1>
+        <p>The abstract operation BuildImmutableProperty takes arguments _value_ (a String, Number, Boolean, Null, or an Object), _name_ (a String), and _reviver_ (an optional function object). It performs the following steps when called:</p>
+        <emu-alg>
+          1. If Type(_value_) is Object, then
+            1. Let _isArray_ be ? IsArray(_val_).
+            1. If _isArray_ is *true*, then
+              1. Let _items_ be a new empty List.
+              1. Let _I_ be 0.
+              1. Let _len_ be ? LengthOfArrayLike(_val_).
+              1. Repeat, while _I_ &lt; _len_,
+                1. Let _childName_ be ! ToString(_I_).
+                1. Let _childValue_ be ? Get(_value_, ! _childName_).
+                1. Let _newElement_ be ? BuildImmutableProperty(_childValue_, _childName_, _reviver_).
+                1. Assert: Type(_newElement_) is not Object.
+                1. Append _newElement_ to _items_.
+                1. Set _I_ to _I_ + 1.
+              1. Let _immutable_ be a new Tuple value whose [[Sequence]] is _items_.
+            1. Else,
+              1. Let _props_ be ? EnumerableOwnPropertyNames(_obj_, ~key+value~).
+              1. Let _fields_ be a new empty List.
+              1. For each element _prop_ of _props_,
+                1. Let _childName_ be ! GetV(_prop_, `"0"`).
+                1. Let _childValue_ be ! GetV(_prop_, `"1"`).
+                1. Let _newElement_ be ? BuildImmutableProperty(_childValue_, _childName_, _reviver_).
+                1. Assert: Type(_newElement_) is not Object.
+                1. If _newElement_ is not *undefined*, then:
+                  1. Let _field_ be the Record { [[Key]]: _childName_, [[Value]]: _newElement_ }.
+                  1. Append _field_ to _fields_.
+              1. Let _immutable_ be a new Record value whose [[Fields]] is _fields_.
+          1. Else,
+            1. Let _immutable_ be _value_.
+          1. If IsCallable(_reviver_) is *true*, then
+            1. Let _immutable_ be ? Call(_reviver_, *undefined*, &laquo; _name_, _immutable_ &raquo;).
+            1. If Type(_immutable_) is Object, throw a *TypeError* exception.
+          1. Return _immutable_.
+        </emu-alg>
+        <p>It is not permitted for a conforming implementation of `JSON.parseImmutable` to extend the JSON grammars. If an implementation wishes to support a modified or extended JSON interchange format it must do so by defining a different parse function.</p>
+        <emu-note>
+          <p>In the case where there are duplicate name Strings within an object, lexically preceding values for the same key shall be overwritten.</p>
+        </emu-note>
+      </emu-clause>
+  
+      <emu-note>
+        <p>There are two differences in the behavior of the _reviver_ parameter of the *JSON.parse* and *JSON.parseImmutable* functions:</p>
+        <ul>
+          <li>*JSON.parse* passes the parent object as the *this* object, while *JSON.parseImmutable* passes *undefined*.</li>
+          <li>When _reviver_ returns *undefined* for an array element, it introduced an hole. When _reviver_ returns *undefined* for a tuple element, *undefined* is used as the resulting value.</li>
+        </ul>
+      </emu-note>
+    </emu-clause>
+  </emu-clause>
+</emu-clause>


### PR DESCRIPTION
This pull request adds the definition of the `JSON.parseImmutable` function.
The implementation proposed here passes `undefined` as the `this` object of the `reviver` function, for the reason explained at https://github.com/tc39/proposal-record-tuple/issues/120#issuecomment-658997804, but we can still change it in the future.