### PR TITLE
Remove mentions of static Record methods

### DIFF
--- a/NS-Proto-Appendix.md
+++ b/NS-Proto-Appendix.md
@@ -236,12 +236,12 @@ Returns a `Tuple` with the same elements as the original `Tuple` except the elem
 - `Object.is()` - When comparing records and tuples it behaves exactly like `===`
 - `Object.entries()`, `Object.keys()`, `Object.values()` - The resulting arrays are sorted alphabetically by key
 - `Object.assign()` - Copy properties from a record or tuple to another object. **Caveat**: The first argument cannot be a record or a tuple, because they are immutable
-- `Object.isExtensible()`, `Object.isFrozen()`, `Object.isSealed()` - They always return `false` for records and tuples
+- `Object.isExtensible()`, `Object.isFrozen()`, `Object.isSealed()` - When called on records and tuples, they always return `false`, `true`, and `true` respectively
 - `Object.preventExtension()`, `Object.freeze()`, `Object.seal()` - Records and tuples are already immutable, so these methods will not throw but won't have any effect
 - `Object.getOwnPropertyDescriptor()`, `Object.getOwnPropertyDescriptors()` - The resulting descriptors all have `writable: false, enumerable: true, configurable: false`
 - `Object.getOwnPropertyNames()`, `Object.getOwnPropertySymbols()`, `Object.getPrototypeOf()` - Behave similarly to when called on objects
 
-- `Object.prototype.toString`, `Object.prototype.toLocaleString` - Return `[object Record]` and `[object Tuple]`
+- `Object.prototype.toString`, `Object.prototype.toLocaleString` - Return `[object Record]` and `[object Tuple]` when a Record or Tuple is the receiver
 - `Object.prototype.valueOf` - Boxes a primitive record or tuple into an object
 - `Object.prototype.propertyIsEnumerable` - Always returns `true` for existing properties
 - `Object.prototype.hasOwnProperty`
@@ -249,5 +249,5 @@ Returns a `Tuple` with the same elements as the original `Tuple` except the elem
 
 ## `Object` methods which don't work with `Record` and `Tuple`
 
-- `Object.create()` - Records and tuples cannot have a prototype
-- `Object.defineProperties()`, `Object.defineProperty()`, `Object.setPrototypeOf()` - Records and tuples are non-observable, not writable by nature
+- `Object.create()` - Records and tuples cannot be used as prototypes, unless you wrap them in objects (`Object(#{})`)
+- `Object.defineProperties()`, `Object.defineProperty()`, `Object.setPrototypeOf()` - Records and tuples are immutable by design.

--- a/NS-Proto-Appendix.md
+++ b/NS-Proto-Appendix.md
@@ -18,10 +18,10 @@ Similar to `Object.fromEntries`, but created a new `Record`.
 - `Object.entries()`
 - `Object.keys()`
 - `Object.values()`
+- `Object.assign()` - **Caveat**: The first argument cannot be a record or a tuple, because they are immutable
 
 ## `Object` namespace functions not working with `Record`
 
-- `Object.assign()` - You can't assign new properties to a record.
 - `Object.create()` - `Record` has no prototype so `Record.create()` would not have any meaning.
 - `Object.defineProperties()`, `Object.defineProperty()` - A `Record` is non-observable, not writable by nature
 - `Object.freeze()`, `Object.seal()` - `Record` is not mutable

--- a/NS-Proto-Appendix.md
+++ b/NS-Proto-Appendix.md
@@ -8,41 +8,27 @@ Converts shallowly an object to a record. If the object has a non-const value, a
 
 Checks whether the parameter is either a Record primitive or Record wrapper.
 
-## `Record.assign(...args: Record[]) -> Record`
-
-Merges all records passed as arguments into one **new** record returned by the function. The latest argument will override arguments before when merging.
-
-## `Record.entries(record: Record) -> Tuple`
-
-Returns all of the entries in a Record as a Tuple of 2-values Tuples (key, value) in the same order as `Record.keys()`.
-
 ## `Record.fromEntries(iterator: Iterator): Record`
 
-Takes an iterator of 2-element array-like values and creates a record out of it. If the iterator returns something other than an array-like tuple, a TypeError will be raised.
+Similar to `Object.fromEntries`, but created a new `Record`.
 
-## `Record.keys(record: Record) -> Tuple`
+## `Object` namespace functions working with `Record`
 
-Returns a Tuple containing the values serving as keys. Order will be the one defined in the main proposal document.
+- `Object.is()`
+- `Object.entries()`
+- `Object.keys()`
+- `Object.values()`
 
-## `Record.toString(record: Record) -> String`
+## `Object` namespace functions not working with `Record`
 
-To be defined - it can actually show the full value.
-
-## `Record.values(record: Record) -> Tuple`
-
-Returns all of the values in a Record in the same order as the associated keys in `Record.keys()`.
-
-## `Object` namespace functions not available in `Record`
-
+- `Object.assign()` - You can't assign new properties to a record.
 - `Object.create()` - `Record` has no prototype so `Record.create()` would not have any meaning.
 - `Object.defineProperties()`, `Object.defineProperty()` - A `Record` is non-observable, not writable by nature
 - `Object.freeze()`, `Object.seal()` - `Record` is not mutable
 - `Object.getOwnPropertyDescriptor()`, `Object.getOwnPropertyDescriptors()` - Does not make sense as there is no `defineProperty`
 - `Object.getOwnPropertyNames()`, `Object.getOwnPropertySymbols()`, `Object.getPrototypeOf()`, `Object.setPrototypeOf()` - Does not make sense without a prototype
-- `Object.is()` - `Record.is()` would be exactly the same as `Object.is()`, we can eventually make it an alias
 - `Object.isExtensible()`, `Object.isFrozen()`, `Object.isSealed()` - `Record` is not mutable anyway
-- `Object.hasOwnProperty()`, `Object.isPrototypeOf()`, `Object.isEnumerable()` - As we can't set those things up as seen previously, those are not available on `Record`
-- `Object.toLocaleString()`, `Object.valueOf()` - Only used by objects overloading Object, we can't overload a Record
+- `Object.isPrototypeOf()`, `Object.isEnumerable()` - As we can't set those things up as seen previously, those are not available on `Record`
 
 # `Tuple` namespace
 

--- a/NS-Proto-Appendix.md
+++ b/NS-Proto-Appendix.md
@@ -12,24 +12,6 @@ Checks whether the parameter is either a Record primitive or Record wrapper.
 
 Similar to `Object.fromEntries`, but created a new `Record`.
 
-## `Object` namespace functions working with `Record`
-
-- `Object.is()`
-- `Object.entries()`
-- `Object.keys()`
-- `Object.values()`
-- `Object.assign()` - **Caveat**: The first argument cannot be a record or a tuple, because they are immutable
-
-## `Object` namespace functions not working with `Record`
-
-- `Object.create()` - `Record` has no prototype so `Record.create()` would not have any meaning.
-- `Object.defineProperties()`, `Object.defineProperty()` - A `Record` is non-observable, not writable by nature
-- `Object.freeze()`, `Object.seal()` - `Record` is not mutable
-- `Object.getOwnPropertyDescriptor()`, `Object.getOwnPropertyDescriptors()` - Does not make sense as there is no `defineProperty`
-- `Object.getOwnPropertyNames()`, `Object.getOwnPropertySymbols()`, `Object.getPrototypeOf()`, `Object.setPrototypeOf()` - Does not make sense without a prototype
-- `Object.isExtensible()`, `Object.isFrozen()`, `Object.isSealed()` - `Record` is not mutable anyway
-- `Object.isPrototypeOf()`, `Object.isEnumerable()` - As we can't set those things up as seen previously, those are not available on `Record`
-
 # `Tuple` namespace
 
 ## `Tuple.from(arrayLike, mapFn, thisArg) => Tuple`
@@ -244,3 +226,28 @@ Returns a `Tuple Iterator` object that contains the values for each index in the
 ## `Tuple.prototype.with(index, value)`
 
 Returns a `Tuple` with the same elements as the original `Tuple` except the element at `index` is replaced with `value`.
+
+# Compatibility with the existing `Object` methods
+
+> NOTE: Since `Record` doesn't inherit from `Object`, you can't directly call the `Object.prototype.*` methods but you have to use `.call()`.
+
+## `Object` methods which work with `Record` and `Tuple`
+
+- `Object.is()` - When comparing records and tuples it behaves exactly like `===`
+- `Object.entries()`, `Object.keys()`, `Object.values()` - The resulting arrays are sorted alphabetically by key
+- `Object.assign()` - Copy properties from a record or tuple to another object. **Caveat**: The first argument cannot be a record or a tuple, because they are immutable
+- `Object.isExtensible()`, `Object.isFrozen()`, `Object.isSealed()` - They always return `false` for records and tuples
+- `Object.preventExtension()`, `Object.freeze()`, `Object.seal()` - Records and tuples are already immutable, so these methods will not throw but won't have any effect
+- `Object.getOwnPropertyDescriptor()`, `Object.getOwnPropertyDescriptors()` - The resulting descriptors all have `writable: false, enumerable: true, configurable: false`
+- `Object.getOwnPropertyNames()`, `Object.getOwnPropertySymbols()`, `Object.getPrototypeOf()` - Behave similarly to when called on objects
+
+- `Object.prototype.toString`, `Object.prototype.toLocaleString` - Return `[object Record]` and `[object Tuple]`
+- `Object.prototype.valueOf` - Boxes a primitive record or tuple into an object
+- `Object.prototype.propertyIsEnumerable` - Always returns `true` for existing properties
+- `Object.prototype.hasOwnProperty`
+- `Object.prototype.isPrototypeOf`
+
+## `Object` methods which don't work with `Record` and `Tuple`
+
+- `Object.create()` - Records and tuples cannot have a prototype
+- `Object.defineProperties()`, `Object.defineProperty()`, `Object.setPrototypeOf()` - Records and tuples are non-observable, not writable by nature

--- a/README.md
+++ b/README.md
@@ -360,10 +360,10 @@ For integrity, out-of-bounds numerical indexing on Tuples returns `undefined`, r
 
 # `Record` and `Tuple` standard library support
 
-The `Record` constructor has functionality broadly analogous to `Object`. Similarly, the `Tuple` constructor is analogous to `Array`.
+`Tuple` values have functionality broadly analogous to `Array`. Similarly, `Record` values are supported by different `Object` static methods.
 
 ```js
-assert(Record.keys(#{ a: 1, b: 2 }) === #["a", "b"]);
+assert(Object.keys(#{ a: 1, b: 2 }) === #["a", "b"]);
 assert(#[1, 2, 3].map(x => x * 2), #[2, 4, 6]);
 ```
 


### PR DESCRIPTION
These methods are not in the spec, and they can be replaced with `Object.*` functions.