### PR TITLE
Rename .sliced to .slice, since .slice doesn't mutate the array

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ console.log(document[3]); // measure error: foo happened
 
 // Slice and spread like arrays!
 const correctedMeasures = #[
-  ...measures.sliced(0, measures.length - 1),
+  ...measures.slice(0, measures.length - 1),
   -1
 ];
 console.log(document[0]); // 42

--- a/cookbook/en.md
+++ b/cookbook/en.md
@@ -211,7 +211,7 @@ console.log(#[1, 2].pushed(3) === #[1, 2, 3]);
 ```
 
 ```js
-console.log(#[1, 2, 3].sliced(1) === #[2, 3]);
+console.log(#[1, 2, 3].spliced(0, 1, 4, 5) === #[4, 5, 2, 3]);
 ```
 
 ```js

--- a/spec/immutable-data-structures.html
+++ b/spec/immutable-data-structures.html
@@ -292,9 +292,9 @@
         </emu-alg>
 
       </emu-clause>
-      <emu-clause id="sec-tuple.prototype.sliced">
-        <h1>Tuple.prototype.sliced ( _start_, _end_ )</h1>
-        <p>When the `sliced` method is called with two arguments, _start_ and _end_, and returns a Tuple containing the elements of the Tuple from element _start_ up to, but not including, element _end_ (or through the end of the tuple if _end_ is *undefined*). If _start_ is negative, it is treated as <emu-eqn>_length_ + _start_</emu-eqn> where _length_ is the length of the tuple. If _end_ is negative, it is treated as <emu-eqn>_length_ + _end_</emu-eqn> where _length_ is the length of the tuple.</p>
+      <emu-clause id="sec-tuple.prototype.slice">
+        <h1>Tuple.prototype.slice ( _start_, _end_ )</h1>
+        <p>When the `slice` method is called with two arguments, _start_ and _end_, and returns a Tuple containing the elements of the Tuple from element _start_ up to, but not including, element _end_ (or through the end of the tuple if _end_ is *undefined*). If _start_ is negative, it is treated as <emu-eqn>_length_ + _start_</emu-eqn> where _length_ is the length of the tuple. If _end_ is negative, it is treated as <emu-eqn>_length_ + _end_</emu-eqn> where _length_ is the length of the tuple.</p>
         <p>The following steps are taken:</p>
         <emu-alg>
           1. Let _T_ be ? thisTupleValue(*this* value).


### PR DESCRIPTION
`.slice` doesn't mutate the array, so we shouldn't rename it.