### PR TITLE
Fix [[Prototype]] of Record and Tuple constructors

### DIFF
--- a/spec/immutable-data-structures.html
+++ b/spec/immutable-data-structures.html
@@ -37,7 +37,7 @@
       <h1>Properties of the Record Constructor</h1>
       <p>The Record constructor:</p>
       <ul>
-        <li>has a [[Prototype]] internal slot whose value is `null`.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
         <li>has the following properties:</li>
       </ul>
       <emu-clause id="sec-record.fromentries">
@@ -126,7 +126,7 @@
       <h1>Properties of the Tuple Constructor</h1>
       <p>The Tuple constructor:</p>
       <ul>
-        <li>has a [[Prototype]] internal slot whose value is %Tuple.prototype%.</li>
+        <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
         <li>has the following properties:</li>
       </ul>
       <emu-clause id="sec-tuple.istuple">


### PR DESCRIPTION
Since those are functions, their internal `[[Prototype]]` slot should be `Function.prototype`. `%Tuple.prototype%` and `null` are already (correctly) used as the values of their `.prototype` property.