### PR TITLE
Fix Tuple.prototype.reversed()

### DIFF
--- a/spec/immutable-data-structures.html
+++ b/spec/immutable-data-structures.html
@@ -272,7 +272,7 @@
           1. Let _oldList_ be a new List containing the elements of _T_.[[Sequence]].
           1. Let _newList_ be a new empty List.
           1. Repeat, while _oldList_ is not empty,
-            1. Remove the first element from _oldList_, and let _E_ be the value of the element.
+            1. Remove the last element from _oldList_, and let _E_ be the value of the element.
             1. Append _E_ to the end of List _newList_.
           1. Return a new Tuple value whose [[Sequence]] is _newList_.
         </emu-alg>


### PR DESCRIPTION
The current spec only creates a clone of the list instead of reversing it.