### PR TITLE
Add support for Boxes

### DIFF
--- a/spec/abstract-operations.html
+++ b/spec/abstract-operations.html
@@ -7,7 +7,7 @@
   <emu-clause id="sec-type-conversion">
     <h1>Type Conversion</h1>
     <p>The ECMAScript language implicitly performs automatic type conversion as needed. To clarify the semantics of certain constructs it is useful to define a set of conversion abstract operations. The conversion abstract operations are polymorphic; they can accept a value of any ECMAScript language type. But no other specification types are used with these operations.</p>
-    <p>The BigInt <ins>, Record, and Tuple</ins> type<ins>s</ins> <del>has</del><ins>have</ins> no implicit conversions in the ECMAScript language; programmers must call BigInt <ins>, Record, or Tuple</ins> explicitly to convert values from other types.</p>
+    <p>The BigInt <ins>, Record, Tuple, and Box</ins> type<ins>s</ins> <del>has</del><ins>have</ins> no implicit conversions in the ECMAScript language; programmers must call BigInt <ins>, Record, Tuple, or Box</ins> explicitly to convert values from other types.</p>
 
     <emu-clause id="sec-toboolean" aoid="ToBoolean">
       <h1>ToBoolean ( _argument_ )</h1>
@@ -90,6 +90,14 @@
           <tr>
             <td>
               <ins>Tuple</ins>
+            </td>
+            <td>
+              <ins>Return *true*.</ins>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <ins>Box</ins>
             </td>
             <td>
               <ins>Return *true*.</ins>
@@ -190,6 +198,14 @@
           <tr>
             <td>
               <ins>Tuple</ins>
+            </td>
+            <td>
+              <ins>Throw a *TypeError* exception.</ins>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <ins>Box</ins>
             </td>
             <td>
               <ins>Throw a *TypeError* exception.</ins>
@@ -307,6 +323,14 @@
                 <ins>Throw a *TypeError* exception.</ins>
               </td>
             </tr>
+            <tr>
+              <td>
+                <ins>Box</ins>
+              </td>
+              <td>
+                <ins>Throw a *TypeError* exception.</ins>
+              </td>
+            </tr>
           </tbody>
         </table>
       </emu-table>
@@ -397,6 +421,14 @@
             </td>
             <td>
               <ins>Return ! TupleToString(_argument_).</ins>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <ins>Box</ins>
+            </td>
+            <td>
+              <ins>Return ? BoxToString(_argument_).</ins>
             </td>
           </tr>
           <tr>
@@ -504,6 +536,14 @@
           </tr>
           <tr>
             <td>
+              <ins>Box</ins>
+            </td>
+            <td>
+              <ins>Return a new Box object whose [[BoxData]] internal slot is set to _argument_. See <emu-xref href="#sec-box-objects"></emu-xref> for a description of Box objects.</ins>
+            </td>
+          </tr>
+          <tr>
+            <td>
               Object
             </td>
             <td>
@@ -607,6 +647,14 @@
           </tr>
           <tr>
             <td>
+              <ins>Box</ins>
+            </td>
+            <td>
+              <ins>Return _argument_.</ins>
+            </td>
+          </tr>
+          <tr>
+            <td>
               Object
             </td>
             <td>
@@ -626,6 +674,7 @@
         1. If Type(_x_) is Number or BigInt, then return ! Type(_x_)::sameValue(_x_, _y_).
         1. <ins>If Type(_x_) is Record, then return ! RecordSameValue(_x_, _y_).</ins>
         1. <ins>If Type(_x_) is Tuple, then return ! TupleSameValue(_x_, _y_).</ins>
+        1. <ins>If Type(_x_) is Box, then return ! BoxSameValue(_x_, _y_).</ins>
         1. <del>Return ! SameValueNonNumeric(_x_, _y_).</del>
         1. <ins>Return ! SameValueNonGeneric(_x_, _y_).</ins>
       </emu-alg>
@@ -642,6 +691,7 @@
         1. If Type(_x_) is Number or BigInt, then return ! Type(_x_)::sameValueZero(_x_, _y_).
         1. <ins>If Type(_x_) is Record, then return ! RecordSameValueZero(_x_, _y_).</ins>
         1. <ins>If Type(_x_) is Tuple, then return ! TupleSameValueZero(_x_, _y_).</ins>
+        1. <ins>If Type(_x_) is Box, then return ! BoxSameValueZero(_x_, _y_).</ins>
         1. <del>Return ! SameValueNonNumeric(_x_, _y_).</del>
         1. <ins>Return ! SameValueNonGeneric(_x_, _y_).</ins>
       </emu-alg>
@@ -685,8 +735,8 @@
         1. If Type(_x_) is String and Type(_y_) is BigInt, return the result of the comparison _y_ == _x_.
         1. If Type(_x_) is Boolean, return the result of the comparison ! ToNumber(_x_) == _y_.
         1. If Type(_y_) is Boolean, return the result of the comparison _x_ == ! ToNumber(_y_).
-        1. If Type(_x_) is either String, Number, BigInt<ins>, Record, Tuple</ins>, or Symbol and Type(_y_) is Object, return the result of the comparison _x_ == ? ToPrimitive(_y_).
-        1. If Type(_x_) is Object and Type(_y_) is either String, Number, BigInt<ins>, Record, Tuple</ins>, or Symbol, return the result of the comparison ? ToPrimitive(_x_) == _y_.
+        1. If Type(_x_) is either String, Number, BigInt<ins>, Record, Tuple, Box</ins>, or Symbol and Type(_y_) is Object, return the result of the comparison _x_ == ? ToPrimitive(_y_).
+        1. If Type(_x_) is Object and Type(_y_) is either String, Number, BigInt<ins>, Record, Tuple, Box</ins>, or Symbol, return the result of the comparison ? ToPrimitive(_x_) == _y_.
         1. If Type(_x_) is BigInt and Type(_y_) is Number, or if Type(_x_) is Number and Type(_y_) is BigInt, then
           1. If _x_ or _y_ are any of *NaN*, *+&infin;*, or *-&infin;*, return *false*.
           1. If the mathematical value of _x_ is equal to the mathematical value of _y_, return *true*; otherwise return *false*.
@@ -701,7 +751,7 @@
         1. If Type(_x_) is different from Type(_y_), return *false*.
         1. If Type(_x_) is Number or BigInt, then
           1. Return ! Type(_x_)::equal(_x_, _y_).
-        1. <ins>If Type(_x_) is Record or Tuple, then</ins>
+        1. <ins>If Type(_x_) is Record, Tuple or Box, then</ins>
           1. <ins>Return ! Type(_x_)::sameValueZero(_x_, _y_).</ins>
         1. <del>Return ! SameValueNonNumeric(_x_, _y_).</del>
         1. <ins>Return ! SameValueNonGeneric(_x_, _y_).</ins>

--- a/spec/data-types-and-values.html
+++ b/spec/data-types-and-values.html
@@ -63,7 +63,6 @@
       </emu-clause>
     </emu-clause>
 
-
     <emu-clause id="sec-ecmascript-language-types-tuple-type">
       <h1>The Tuple Type</h1>
       <p>The Tuple type is the set of all finite and ordered sequences of ECMAScript primitive values including Record and Tuple. Each tuple value holds an associated [[Sequence]] List which is a list of primitive values. The [[Sequence]] List is integer-indexed. The [[Sequence]] List and its values are never modified.</p>
@@ -112,6 +111,40 @@
           1. Let _elementEqual_ be a new Abstract Closure with parameters (_elementX_, _elementY_) that captures no values and performs the following steps when called:
             1. Return ! SameValueZero(_elementX_, _elementY_).
           1. Return ! TupleEqual(_x_, _y_, _elementEqual_).
+        </emu-alg>
+      </emu-clause>
+    </emu-clause>
+
+    <emu-clause id="sec-ecmascript-language-types-box-type">
+      <h1>The Box Type</h1>
+      <p>The Box type is the set of all the possible singleton primitive wrappers around any ECMAScript value. Each box vale holds an associated [[Value]] containing an ECMAScript value. The [[Value]] internal slot is never modified.</p>
+
+      <emu-clause id="sec-ecmascript-language-types-box-tostring">
+        <h1>BoxToString ( _argument_ )</h1>
+        <p>The abstract operation BoxToString takes the argument _argument_ (a Box). It performs the following steps when called:</p>
+        <emu-alg>
+          1. Let _valueString_ be ? ToString(_argument_.[[Value]]).
+          1. Return the string-concatenation of *"Box("*, _valueString_, and *")"*.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-ecmascript-language-types-box-samevalue">
+        <h1>BoxSameValue ( _x_, _y_ )</h1>
+        <p>The abstract operation BoxSameValue takes arguments _x_ (a Box) and _y_ (a Box). It performs the following steps when called:</p>
+        <emu-alg>
+          1. Let _xValue_ be _x_.[[Value]].
+          1. Let _yValue_ be _y_.[[Value]].
+          1. Return ! SameValue(_xValue_, _yValue_.)
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-ecmascript-language-types-box-samevaluezero">
+        <h1>BoxSameValueZero ( _x_, _y_ )</h1>
+        <p>The abstract operation BoxSameValueZero takes arguments _x_ (a Box) and _y_ (a Box). It performs the following steps when called:</p>
+        <emu-alg>
+          1. Let _xValue_ be _x_.[[Value]].
+          1. Let _yValue_ be _y_.[[Value]].
+          1. Return ! SameValueZero(_xValue_, _yValue_.)
         </emu-alg>
       </emu-clause>
     </emu-clause>

--- a/spec/data-types-and-values.html
+++ b/spec/data-types-and-values.html
@@ -117,7 +117,8 @@
 
     <emu-clause id="sec-ecmascript-language-types-box-type">
       <h1>The Box Type</h1>
-      <p>The Box type is the set of all the possible singleton primitive wrappers around any ECMAScript value. Each box vale holds an associated [[Value]] containing an ECMAScript value. The [[Value]] internal slot is never modified.</p>
+      <p>The Box type is the set of all the possible singleton primitive wrappers around any ECMAScript value. Each box value holds an associated [[Value]] containing an ECMAScript value. The [[Value]] internal slot is never modified.</p>
+
 
       <emu-clause id="sec-ecmascript-language-types-box-tostring">
         <h1>BoxToString ( _argument_ )</h1>

--- a/spec/expression.html
+++ b/spec/expression.html
@@ -330,6 +330,14 @@
             </tr>
             <tr>
               <td>
+                <ins>Box</ins>
+              </td>
+              <td>
+                <ins>*"box"*</ins>
+              </td>
+            </tr>
+            <tr>
+              <td>
                 Object (does not implement [[Call]])
               </td>
               <td>

--- a/spec/fundamental-objects.html
+++ b/spec/fundamental-objects.html
@@ -26,6 +26,7 @@
           1. Else if _O_ has a [[RegExpMatcher]] internal slot, let _builtinTag_ be *"RegExp"*.
           1. <ins>Else if _O_ has a [[RecordData]] internal slot, let _builtinTag_ be *"Record"*.</ins>
           1. <ins>Else if _O_ has a [[TupleData]] internal slot, let _builtinTag_ be *"Tuple"*.</ins>
+          1. <ins>Else if _O_ has a [[BoxData]] internal slot, let _builtinTag_ be *"Box"*.</ins>
           1. Else, let _builtinTag_ be *"Object"*.
           1. Let _tag_ be ? Get(_O_, @@toStringTag).
           1. If Type(_tag_) is not String, set _tag_ to _builtinTag_.

--- a/spec/immutable-data-structures.html
+++ b/spec/immutable-data-structures.html
@@ -642,4 +642,109 @@
       </emu-clause>
     </emu-clause>
   </emu-clause>
+
+  <emu-clause id="sec-box-objects">
+    <h1>Box Objects</h1>
+    <emu-clause id="sec-box-constructor">
+      <h1>The Box Constructor</h1>
+      <p>The Box constructor:</p>
+      <ul>
+        <li>is the intrinsic object <dfn>%Box%</dfn>.</li>
+        <li>is the initial value of the *"Box"* property of the global object.</li>
+        <li>creates and initializes a new Box value when called as a function.</li>
+        <li>is not intended to be used with the `new` operator or to be subclassed. It may be used as the value of an *extends* clause of a class definition but a *super* call to the Box constructor will cause an exception.</li>
+      </ul>
+      <emu-clause id="sec-box-constructor-box-value">
+        <h1>Box ( _arg_ )</h1>
+        <p>When the `Box` function is called, the following steps are taken:</p>
+        <emu-alg>
+          1. If NewTarget is not *undefined*, throw a *TypeError* exception.
+          1. Return a new Box value whose [[Value]] is _arg_.
+        </emu-alg>
+      </emu-clause>
+    </emu-clause>
+
+    <emu-clause id="sec-properties-of-the-box-constructor">
+      <h1>Properties of the Box Constructor</h1>
+      <p>The Box constructor:</p>
+      <ul>
+        <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
+        <li>has the following properties:</li>
+      </ul>
+
+      <emu-clause id="sec-box.containsboxes">
+        <h1>Box.containsBoxes ( _arg_ )</h1>
+        <p>The *containsBoxes* function takes one argument _arg_, and performs the following steps:</p>
+        <emu-alg>
+          1. If Type(_arg_) is not Record or Tuple, throw a *TypeError* exception.
+          1. Return ! RecursiveContainsBoxes(_arg_).
+        </emu-alg>
+
+        <emu-clause id="sec-recursivecontainsboxes" aoid="RecursiveContainsBoxes">
+          <h1>RecursiveContainsBoxes ( _value_ )</h1>
+          <p>The abstract operation RecursiveContainsBoxes takes the argument _value_. It performs the following steps when called:</p>
+          <emu-alg>
+            1. Assert: Type(_value_) is not Object.
+            1. If Type(_value_) is Box, return *true*.
+            1. If Type(_value_) is Record, then
+              1. For each _field_ of _value_.[[Fields]], do
+                1. If ! RecursiveContainsBoxes(_field_.[[Value]]) is *true*, return *true*.
+            1. If Type(_value_) is Tuple,
+              1. For each _item_ of _value_.[[Sequence]], do
+                1. If ! RecursiveContainsBoxes(_item_) is *true*, return *true*.
+            1. Return *false*.
+          </emu-alg>
+        </emu-clause>
+      </emu-clause>
+
+      <emu-clause id="sec-box.prototype">
+        <h1>Box.prototype</h1>
+        <p>The initial value of *Box.prototype* is %Box.prototype%</p>
+        <p>This property has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: false }.</p>
+      </emu-clause>
+    </emu-clause>
+
+    <emu-clause id="sec-properties-of-the-box-prototype-object">
+      <h1>Properties of the Box Prototype Object</h1>
+      <p>The Box prototype object:</p>
+      <ul>
+        <li>is an ordinary object.</li>
+        <li>is not a Box object; it does not have a [[BoxData]] internal slot.</li>
+        <li>has a [[Prototype]] internal slot whose value is *null*.</li>
+      </ul>
+      <p>The abstract operation <dfn id="sec-thisboxvalue" aoid="thisBoxValue">thisBoxValue</dfn> takes argument _value_. It performs the following steps when called:</p>
+      <emu-alg>
+        1. If Type(_value_) is Box, return _value_.
+        1. If Type(_value_) is Object and _value_ has a [[BoxData]] internal slot, then
+          1. Let _box_ be _value_.[[BoxValue]].
+          1. Assert: Type(_box_) is Box.
+          1. Return _box_.
+        1. Throw a *TypeError* exception.
+      </emu-alg>
+      <emu-clause id="sec-box.prototype.constructor">
+        <h1>Box.prototype.constructor</h1>
+        <p>The initial value of *Box.prototype.constructor* is the intrinsic object %Box%</p>
+      </emu-clause>
+      <emu-clause id="sec-box.prototype.valueof">
+        <h1>Box.prototype.valueOf ( )</h1>
+        <p>When the `valueOf` function is called, the following steps are taken:</p>
+        <emu-alg>
+          1. Return ? thisBoxValue(*this* value).
+        </emu-alg>
+      </emu-clause>
+      <emu-clause id="sec-box.prototype-@@toStringTag">
+        <h1>Box.prototype [ @@toStringTag ]</h1>
+        <p>The initial value of *Box.prototype[@@toStringTag]* is the String value *"Box"*.</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+      </emu-clause>
+      <emu-clause id="sec-box.prototype.unbox">
+        <h1>Box.prototype.unbox ( )</h1>
+        <p>When the `unbox` function is called, the following steps are taken:</p>
+        <emu-alg>
+          1. Let _box_ be ? thisBoxValue(*this* value).
+          1. Return _box_.[[Value]]
+        </emu-alg>
+      </emu-clause>
+    </emu-clause>
+  </emu-clause>
 </emu-clause>

--- a/spec/immutable-data-structures.html
+++ b/spec/immutable-data-structures.html
@@ -676,7 +676,7 @@
         <h1>Box.containsBoxes ( _arg_ )</h1>
         <p>The *containsBoxes* function takes one argument _arg_, and performs the following steps:</p>
         <emu-alg>
-          1. If Type(_arg_) is not Record or Tuple, throw a *TypeError* exception.
+          1. If Type(_arg_) is not Record, Tuple or Box, throw a *TypeError* exception.
           1. Return ! RecursiveContainsBoxes(_arg_).
         </emu-alg>
 

--- a/spec/ordinary-and-exotic-object-behaviours.html
+++ b/spec/ordinary-and-exotic-object-behaviours.html
@@ -138,7 +138,7 @@
           1. Return *false*.
         </emu-alg>
       </emu-clause>
-      
+
       <emu-clause id="sec-recordget-r-p" aoid="RecordGet">
         <h1>RecordGet ( _R_, _P_ )</h1>
         <p>This abstract operation RecordGet takes arguments _R_ and _P_. It performs the following steps when called:</p>
@@ -311,6 +311,83 @@
           1. If ! IsValidTupleIndex(_numericIndex_) is *false*, return ~empty~.
           1. Let _value_ be the element with index _numericIndex_ in _tup_.[[Sequence]].
           1. Return _value_.
+        </emu-alg>
+      </emu-clause>
+    </emu-clause>
+
+    <emu-clause id="sec-box-exitic-objects">
+      <h1>Box Exotic Objects</h1>
+      <p>A Box object is an exotic object that encapsuates a Box value and exposes virtual integer-indexed data properties corresponding to the individual entries set on the underlying Box value. All keys properties are non-writable and non-configurable.</p>
+
+      <p>An object is a <dfn id="box-exotic-object">Box exotic object</dfn> (or simply, a Box object) if its following internal methods use the following implementations and is an <emu-xref href="#sec-immutable-prototype-exotic-objects">Immutable Prototype Exotic Object</emu-xref>..</p>
+
+      <p>Box exotic objects have the same internal slots as ordinary objects. They also have a [[BoxData]] internal slot.</p>
+
+      <emu-clause id="sec-box-exotic-objects-isextensible">
+        <h1>[[IsExtensible]] ()</h1>
+        <p>When the [[IsExtensible]] internal method of a Box exotic object _T_ is called, the following steps are taken:</p>
+        <emu-alg>
+          1. Return *false*.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-box-exotic-objects-getownproperty-p">
+        <h1>[[GetOwnProperty]] ( _P_ )</h1>
+        <p>When the [[GetOwnProperty]] internal method of a Box exotic object _T_ is called with property key _P_, the following steps are taken:</p>
+        <emu-alg>
+          1. Return *false*.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-box-exotic-objects-defineownproperty-p-desc">
+        <h1>[[DefineOwnProperty]] ( _P_, _Desc_ )</h1>
+        <p>When the [[DefineOwnProperty]] internal method of a Box exotic object _T_ is called with property key _P_, and Property Descriptor _Desc_ the following steps are taken:</p>
+        <emu-alg>
+          1. Return *false*.
+        </emu-alg>
+      </emu-clause>
+      
+      <emu-clause id="sec-box-exotic-objects-hasproperty-p">
+        <h1>[[HasProperty]] ( _P_ )</h1>
+        <p>When the [[HasProperty]] internal method of a Box exotic object _T_ is called with property key _P_, the following steps are taken:</p>
+        <emu-alg>
+          1. Assert: IsPropertyKey(_P_) is *true*.
+          1. Let _parent_ be %Box.prototype%.
+          1. Return ? _parent_.[[HasProperty]](_P_).
+        </emu-alg>
+      </emu-clause>
+            
+      <emu-clause id="sec-box-exotic-objects-get-p-receiver">
+        <h1>[[Get]] ( _P_, _Receiver_ )</h1>
+        <p>When the [[Get]] internal method of a Box exotic object _T_ is called with property key _P_ and ECMAScript language value _Receiver_, the following steps are taken:</p>
+        <emu-alg>
+          1. Assert: IsPropertyKey(_P_) is *true*.
+          1. Let _parent_ be ? %Box.prototype%.
+          1. Return ? _parent_.[[Get]](_P_, _Receiver_).
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-box-exotic-objects-set-p-receiver">
+        <h1>[[Set]] ( _P_, _Receiver_ )</h1>
+        <p>When the [[Set]] internal method of a Box exotic object _T_ is called with property key _P_ and ECMAScript language value _Receiver_, the following steps are taken:</p>
+        <emu-alg>
+          1. Return *false*.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-box-exotic-objects-delete-p">
+        <h1>[[Delete]] ( _P_ )</h1>
+        <p>When the [[Delete]] internal method of a Box exotic object _T_ is called with property key _P_, the following steps are taken:</p>
+        <emu-alg>
+          1. Return *true*.
+        </emu-alg>
+      </emu-clause>
+      
+      <emu-clause id="sec-box-exotic-objects-ownpropertykeys">
+        <h1>[[OwnPropertyKeys]] ( )</h1>
+        <p>When the [[OwnPropertyKeys]] internal method of a Record exotic object _T_ is called, the following steps are taken:</p>
+        <emu-alg>
+          1. Return a new empty List.
         </emu-alg>
       </emu-clause>
     </emu-clause>

--- a/spec/ordinary-and-exotic-object-behaviours.html
+++ b/spec/ordinary-and-exotic-object-behaviours.html
@@ -319,7 +319,7 @@
       <h1>Box Exotic Objects</h1>
       <p>A Box object is an exotic object that encapsuates a Box value and exposes virtual integer-indexed data properties corresponding to the individual entries set on the underlying Box value. All keys properties are non-writable and non-configurable.</p>
 
-      <p>An object is a <dfn id="box-exotic-object">Box exotic object</dfn> (or simply, a Box object) if its following internal methods use the following implementations and is an <emu-xref href="#sec-immutable-prototype-exotic-objects">Immutable Prototype Exotic Object</emu-xref>..</p>
+      <p>An object is a <dfn id="box-exotic-object">Box exotic object</dfn> (or simply, a Box object) if its following internal methods use the following implementations and it is an <emu-xref href="#sec-immutable-prototype-exotic-objects">Immutable Prototype Exotic Object</emu-xref>.</p>
 
       <p>Box exotic objects have the same internal slots as ordinary objects. They also have a [[BoxData]] internal slot.</p>
 

--- a/spec/overview.html
+++ b/spec/overview.html
@@ -18,7 +18,7 @@
       member of one of the following built-in types: <b>Undefined</b>,
       <b>Null</b>, <b>Boolean</b>, <b>Number</b>, <b>BigInt</b>, <b>String</b>,
       <del>and</del> <b>Symbol<del>;</del></b
-      ><ins>, <b>Record</b>, <b>Tuple</b> and <b>Box</b>;</b></ins> an object is a member of the
+      ><ins>, <b>Record</b>, <b>Tuple</b> and <b>Box</b>;</ins> an object is a member of the
       built-in type <b>Object</b>; and a function is a callable object. A
       function that is associated with an object via a property is called a
       <em>method</em>.

--- a/spec/overview.html
+++ b/spec/overview.html
@@ -125,7 +125,7 @@
       </p>
       <emu-note>
         <p>
-          A box is immutable and its will always contain the same value over time. However, the contents of such value can change if it is not immutable.
+          A box is immutable and it will always contain the same reference over time. However, it does not guarantee that mutable referenced values will not be mutated.
         </p>
     </emu-clause>
     <emu-clause id="sec-box-type">

--- a/spec/overview.html
+++ b/spec/overview.html
@@ -18,7 +18,7 @@
       member of one of the following built-in types: <b>Undefined</b>,
       <b>Null</b>, <b>Boolean</b>, <b>Number</b>, <b>BigInt</b>, <b>String</b>,
       <del>and</del> <b>Symbol<del>;</del></b
-      ><ins>, <b>Record</b>, and <b>Tuple;</b></ins> an object is a member of the
+      ><ins>, <b>Record</b>, <b>Tuple</b> and <b>Box</b>;</b></ins> an object is a member of the
       built-in type <b>Object</b>; and a function is a callable object. A
       function that is associated with an object via a property is called a
       <em>method</em>.
@@ -28,7 +28,7 @@
       out the definition of ECMAScript entities. These built-in objects include
       the global object; objects that are fundamental to the runtime semantics
       of the language including `Object`, `Function`, `Boolean`, `Symbol`,
-      <ins>`Record`, `Tuple`</ins> and various `Error` objects; objects that
+      <ins>`Record`, `Tuple`, `Box`</ins> and various `Error` objects; objects that
       represent and manipulate numeric values including `Math`, `Number`, and
       `Date`; the text processing objects `String` and `RegExp`; objects that
       are indexed collections of values including `Array` and nine different
@@ -114,6 +114,37 @@
             href="#sec-tuple-items"
           ></emu-xref
           >).
+        </p>
+      </emu-note>
+    </emu-clause>
+
+    <emu-clause id="sec-box-value">
+      <h1>Box value</h1>
+      <p>
+        primitive value which contains an ECMAScript value
+      </p>
+      <emu-note>
+        <p>
+          A box is immutable and its will always contain the same value over time. However, the contents of such value can change if it is not immutable.
+        </p>
+    </emu-clause>
+    <emu-clause id="sec-box-type">
+      <h1>Box type</h1>
+      <p>
+        set of all Box values
+      </p>
+    </emu-clause>
+    <emu-clause id="sec-box-object">
+      <h1>Box object</h1>
+      <p>
+        member of the Object type that is an instance of the standard built-in
+        `Box` constructor
+      </p>
+      <emu-note>
+        <p>
+          A Box object is created by using the `Object` function in a call
+          expression, supplying an Box value as an argument. The resulting
+          object has an internal slot whose value is the Box value.
         </p>
       </emu-note>
     </emu-clause>


### PR DESCRIPTION
This PR shows how boxes can fit the current proposal, making it possible to store mutable state inside of records and tuples.
In order to store an object inside a record/tuple, it must be wrapped via `Box(obj)`, and it the wrapped value can be obtained using `box.unbox()`.

Open questions:
1. Should `===` defer to the boxed values, or behave like it does for records? i.e. `Box(NaN) === Box(NaN)`?
    - 👍 note by @rricard: looks like from the thread: yes it should defer to the values and is spec'ed as-so
1. Should `ToNumber(box)` and `ToBoolean(box)` return the result of calling that operation on the boxed value?
    - 👍 note by @rricard: looks like from the thread: no and is spec'ed as-so
1. Should boxes be only allowed to contain objects? Any value? Any value except for boxes?
    - 👍 note by @rricard: looks like from the thread: yes and any value is accepted as of now
1. Should `Box.containsBoxes` be moved to the `Record` constructor, similarly to how utility methods for mutable things are on `Object`?
    - ❓ note by @rricard: I think we might want to put that in a meta containsBoxes issue #231
1. How should `Box.containsBoxes` be named?
    - ❓ note by @rricard: I think we might want to put that in a meta containsBoxes issue #231
1. Should `Box.containsBoxes` throw on invalid values, or return `false`?
    - 👍 note by @rricard: looks like from the thread: yes and is specced as-so now but we can always add to the meta-issue
1. Should `Box.containsBoxes` return `true` or `false` when called on a box?
    - 👍 note by @rricard: yes and is implemented as-so but we can always add to the meta-issue
1. Should `Box.containsBoxes` unwrap its argument?
   - 👍 note by @rricard: personally I'd say no and is specced as-so but we can always add to the meta-issue
1. What should the name of the function to get a box's contents be? `unbox`, `unwrap`, `deref`, `get`?
   - 👍 note by @rricard: unbox as it is right now - we used that nomenclature for a while now
1. Should boxes be unwrapped when calling `JSON.stringify`?
    - 👷‍♂️ note by @rricard: I might want to address that now or in a follow-on PR: the expectation looks like yes #232

---

**EDIT**: Additional items added by @rricard:

1. ~~Add an originating Realm check when unboxing: if the current Realm does not match the Realm where the box was created, throw a runtime error.~~ Realms will probably want to latch on `RecursiveContainsBoxes` and throw if they see a Box for now. 
1. 👷‍♂️ Add boxes as weakmapkeys: a box would be weak on what it contains, this can be done as a follow-on pr #233