### PR TITLE
Consistently sort record fields

### DIFF
--- a/spec/abstract-operations.html
+++ b/spec/abstract-operations.html
@@ -765,6 +765,15 @@
   <emu-clause id="sec-operations-on-records">
     <h1>Operations on Records</h1>
 
+    <emu-clause id="sec-createrecord" aoid="CreateRecord">
+      <h1>CreateRecord ( _entries_ )</h1>
+      <p>This abstract operation CreateRecord takes a _entries_ argument. It is used to create a Record value ensuring that its fields are sorted. It performs the following steps when called:</p>
+      <emu-alg>
+        1. Let _sortedEntries_ be a new List containing the values of _entries_ sorted such that, for any entry two entries _a_ and _b_, _a_ will be placed before _b_ if the result of performing Abstract Relational Comparison _a_.[[Key]] < _b_.[[Key]] is *true*.
+        1. Return a new Record value whose [[Fields]] is _sortedEntries_.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-addpropertyintorecordentrieslist" aoid="AddPropertyIntoRecordEntriesList">
       <h1>AddPropertyIntoRecordEntriesList ( _entries_, _propName_, _value_ )</h1>
       <p>This abstract operation AddPropertyIntoRecordEntriesList takes _entries_, _propName_ and _value_ arguments. It is used during a single assignment into a Record literal expression. It performs the following steps when called:</p>

--- a/spec/expression.html
+++ b/spec/expression.html
@@ -98,9 +98,7 @@
             1. Assert: Type(_kv_.[[Key]]) is String.
             1. Assert: Type(_kv_.[[Value]]) is not Object.
             1. If there is no entry _existing_ in _uniqueEntries_ such that _existing_.[[Key]] is _kv_.[[Key]], append _kv_ to _uniqueEntries_.
-          1. Let _sortedEntries_ be a new List containing the values of _uniqueEntries_ sorted such that, for any entry two entries _a_ and _b_, _a_ will be placed before _b_ if the result of performing Abstract Relational Comparison _a_.[[Key]] < _b_.[[Key]] is *true*.
-          1. Let _rec_ be a Record value whose [[Fields]] value is _sortedEntries_.
-          1. Return _rec_.
+          1. Return ! CreateRecord(_uniqueEntries_).
         </emu-alg>
       </emu-clause>
 

--- a/spec/immutable-data-structures.html
+++ b/spec/immutable-data-structures.html
@@ -29,7 +29,7 @@
             1. If Type(_value_) is Object, throw a *TypeError* exception.
             1. Let _field_ be the Record { [[Key]]: _name_, [[Value]]: _value_ }.
             1. Append _field_ to the end of list _fields_.
-          1. Return a new Record value whose [[Fields]] is _fields_.
+          1. Return ! CreateRecord(_fields_).
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -51,7 +51,7 @@
             1. Let _field_ be { [[Key]]: _key_, [[Value]]: _value_ }.
             1. Append _field_ to the end of list _fields_.
           1. Perform ! AddEntriesFromIterable(*undefined*, _iterable_, _adder_).
-          1. Return a new Record value whose [[Fields]] is _fields_.
+          1. Return ! CreateRecord(_fields_).
         </emu-alg>
         <emu-note>
           <p>The parameter _iterable_ is expected to be an object that implements an @@iterator method that returns an iterator object that produces a two element array-like object whose first element is a value that will be used as a Map key and whose second element is the value to associate with that key.</p>

--- a/spec/structured-data.html
+++ b/spec/structured-data.html
@@ -85,7 +85,7 @@
                 1. If _newElement_ is not *undefined*, then:
                   1. Let _field_ be the Record { [[Key]]: _childName_, [[Value]]: _newElement_ }.
                   1. Append _field_ to _fields_.
-              1. Let _immutable_ be a new Record value whose [[Fields]] is _fields_.
+              1. Let _immutable_ be ! CreateRecord(_fields_).
           1. Else,
             1. Let _immutable_ be _value_.
           1. If IsCallable(_reviver_) is *true*, then


### PR DESCRIPTION
Record fields were sorted only when created with the `#{ ... }` syntax, and not when created by a built-in function.
This PR consistently sorts them, so that the algorithms relying on a well-defined order (for example, `RecordEqual` don't break.