### PR TITLE
Replace `Box.containsBoxes` with `Object.containsObject`

### DIFF
--- a/spec/fundamental-objects.html
+++ b/spec/fundamental-objects.html
@@ -5,6 +5,34 @@
   <emu-clause id="sec-object-objects">
     <h1>Object Objects</h1>
 
+    <emu-clause id="sec-properties-of-the-object-constructor">
+      <h1>Properties of the Object Constructor</h1>
+
+      <emu-clause id="sec-object.containsobject">
+        <h1><ins>Object.containsObject ( _arg_ )</ins></h1>
+        <p>The *containsObject* function takes one argument _arg_, and performs the following steps:</p>
+        <emu-alg>
+          1. Return ! RecursiveContainsObjects(_arg_).
+        </emu-alg>
+
+        <emu-clause id="sec-recursivecontainsobject" aoid="RecursiveContainsObject">
+          <h1><ins>RecursiveContainsObject ( _value_ )</ins></h1>
+          <p>The abstract operation RecursiveContainsObject takes the argument _value_. It performs the following steps when called:</p>
+          <emu-alg>
+            1. If Type(_value_) is Object, return *true*.
+            1. If Type(_value_) is Box, return ! RecursiveContainsObject(_value_.[[Value]]).
+            1. If Type(_value_) is Record, then
+              1. For each _field_ of _value_.[[Fields]], do
+                1. If ! RecursiveContainsObject(_field_.[[Value]]) is *true*, return *true*.
+            1. If Type(_value_) is Tuple,
+              1. For each _item_ of _value_.[[Sequence]], do
+                1. If ! RecursiveContainsObject(_item_) is *true*, return *true*.
+            1. Return *false*.
+          </emu-alg>
+        </emu-clause>
+      </emu-clause>
+    </emu-clause>
+
     <emu-clause id="sec-properties-of-the-object-prototype-object">
       <h1>Properties of the Object Prototype Object</h1>
       <emu-clause id="sec-object.prototype.tostring">

--- a/spec/immutable-data-structures.html
+++ b/spec/immutable-data-structures.html
@@ -649,31 +649,6 @@
         <li>has the following properties:</li>
       </ul>
 
-      <emu-clause id="sec-box.containsboxes">
-        <h1>Box.containsBoxes ( _arg_ )</h1>
-        <p>The *containsBoxes* function takes one argument _arg_, and performs the following steps:</p>
-        <emu-alg>
-          1. If Type(_arg_) is not Record, Tuple or Box, throw a *TypeError* exception.
-          1. Return ! RecursiveContainsBoxes(_arg_).
-        </emu-alg>
-
-        <emu-clause id="sec-recursivecontainsboxes" aoid="RecursiveContainsBoxes">
-          <h1>RecursiveContainsBoxes ( _value_ )</h1>
-          <p>The abstract operation RecursiveContainsBoxes takes the argument _value_. It performs the following steps when called:</p>
-          <emu-alg>
-            1. Assert: Type(_value_) is not Object.
-            1. If Type(_value_) is Box, return *true*.
-            1. If Type(_value_) is Record, then
-              1. For each _field_ of _value_.[[Fields]], do
-                1. If ! RecursiveContainsBoxes(_field_.[[Value]]) is *true*, return *true*.
-            1. If Type(_value_) is Tuple,
-              1. For each _item_ of _value_.[[Sequence]], do
-                1. If ! RecursiveContainsBoxes(_item_) is *true*, return *true*.
-            1. Return *false*.
-          </emu-alg>
-        </emu-clause>
-      </emu-clause>
-
       <emu-clause id="sec-box.prototype">
         <h1>Box.prototype</h1>
         <p>The initial value of *Box.prototype* is %Box.prototype%</p>


### PR DESCRIPTION
This is a possible alternative to https://github.com/tc39/proposal-record-tuple/issues/231.

Boxes are currently allowed to contain any value (also primitives), but for membrane purposes we only need to know if a record/tuple/box deeply contains an _object_ so that we can wrap it.

If we'll allow putting boxes containing an object in WeakMaps, "`x` can be put in a WeakMap" will effectively be `Object.containsObject(x)` (unless one day WeakMaps will allow symbols as keys).