### PR TITLE
Unwrap boxes in `JSON.stringify`

### DIFF
--- a/spec/structured-data.html
+++ b/spec/structured-data.html
@@ -116,12 +116,23 @@
         <p>The abstract operation SerializeJSONProperty takes arguments _state_, _key_, and _holder_. It performs the following steps when called:</p>
         <emu-alg>
           1. Let _value_ be ? Get(_holder_, _key_).
+          1. <ins>Let _toJSONCalled_ be *false*.</ins>
           1. If Type(_value_) is Object or BigInt, then
             1. Let _toJSON_ be ? GetV(_value_, *"toJSON"*).
             1. If IsCallable(_toJSON_) is *true*, then
               1. Set _value_ to ? Call(_toJSON_, _value_, &laquo; _key_ &raquo;).
+              1. <ins>Set _toJSONCalled_ to *true*.</ins>
           1. If _state_.[[ReplacerFunction]] is not *undefined*, then
             1. Set _value_ to ? Call(_state_.[[ReplacerFunction]], _holder_, &laquo; _key_, _value_ &raquo;).
+            1. <ins>Set _value_ to ! MaybeUnwrapBox(_value_).</ins>
+          1. <ins>Else,</ins>
+            1. <ins>Set _value_ to ! MaybeUnwrapBox(_value_).</ins>
+            1. <ins>If _toJSONCalled_ is *false*, then</ins>
+              1. <ins>If Type(_value_) is Object or BigInt, then</ins>
+              1. <ins>Let _toJSON_ be ? GetV(_value_, *"toJSON"*).</ins>
+              1. <ins>If IsCallable(_toJSON_) is *true*, then</ins>
+                1. <ins>Set _value_ to ? Call(_toJSON_, _value_, &laquo; _key_ &raquo;).</ins>
+                1. <ins>Set _value_ to ! MaybeUnwrapBox(_value_).</ins>
           1. If Type(_value_) is Object, then
             1. If _value_ has a [[NumberData]] internal slot, then
               1. Set _value_ to ? ToNumber(_value_).
@@ -131,10 +142,10 @@
               1. Set _value_ to _value_.[[BooleanData]].
             1. Else if _value_ has a [[BigIntData]] internal slot, then
               1. Set _value_ to _value_.[[BigIntData]].
-          1. <ins>If Type(_value_) is Record or Type(_value_) is Tuple, set _value_ to ! ToObject(_value_).</ins>
           1. If _value_ is *null*, return *"null"*.
           1. If _value_ is *true*, return *"true"*.
           1. If _value_ is *false*, return *"false"*.
+          1. <ins>If Type(_value_) is Record or Type(_value_) is Tuple, set _value_ to ! ToObject(_value_).</ins>
           1. If Type(_value_) is String, return QuoteJSONString(_value_).
           1. If Type(_value_) is Number, then
             1. If _value_ is finite, return ! ToString(_value_).
@@ -149,6 +160,17 @@
             1. If <del>_isArray_</del><ins>_isArrayLike_</ins> is *true*, return ? SerializeJSONArray(_state_, _value_).
             1. Return ? SerializeJSONObject(_state_, _value_).
           1. Return *undefined*.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-maybeunwrapbox" aoid="MaybeUnwrapBox">
+        <h1><ins>Runtime Semantics: MaybeUnwrapBox ( _value_ )</ins></h1>
+        <p>The abstract operation MaybeUnwrapBox takes a single argument, _value_. It performs the following steps when called:</p>
+        <emu-alg>
+          1. If Type(_value_) is Object and _value_ has a [[BoxData]] internal slot,
+            1. Set _value_ to _value_.[[BoxData]].
+          1. If Type(_value_) is Box, return ! MaybeUnwrapBox(_value_.[[Value]]).
+          1. Return _value_.
         </emu-alg>
       </emu-clause>
     </emu-clause>


### PR DESCRIPTION
This is a draft implementation that fixes https://github.com/tc39/proposal-record-tuple/issues/232.

I tried to respect the following constraints which are already respected by the current `JSON.stringify` implementation:
1. `.toJSON` is called at most once
2. `.toJSON` can only be called before calling the replacer

And I added the following rules:
1. boxes are never unboxed before calling the replacer (so that you can have a custom serialization for them - https://github.com/tc39/proposal-record-tuple/issues/232#issuecomment-878992408)
2. objects inside boxes can still be `.toJSON`ed
3. nested boxes are recursively unboxed
4. boxes are always unboxes before trying to serialize them

I decided not to implement this property, which is an alternative to (1) (they cannot be both implemented):
<ol start=5><li>

If there is a replacer function and there is a box containing an object with a `.toJSON` method, `.toJSON` is called and it happens before calling the replacer

</li></ol>

If we want to make boxes fully transparent, we can replace (1) with (5).

cc @acutmore