### PR TITLE
Update boxes to work in SES environments

### DIFF
--- a/spec/abstract-operations.html
+++ b/spec/abstract-operations.html
@@ -769,8 +769,8 @@
     <emu-clause id="sec-samevaluenongeneric" type="abstract operation" oldids="sec-samevaluenonnumeric sec-samevaluenonnumber">
       <h1>
         <del>SameValueNonNumeric</del><ins>SameValueNonGeneric</ins> (
-          _x_: an ECMAScript language value, but not a Number or a BigInt,
-          _y_: an ECMAScript language value, but not a Number or a BigInt,
+          _x_: an ECMAScript language value, but not a Number, a BigInt, a Record, a Tuple, or a Box,
+          _y_: an ECMAScript language value, but not a Number, a BigInt, a Record, a Tuple, or a Box,
         )
       </h1>
       <dl class="header">
@@ -778,7 +778,6 @@
         <dd>It returns a completion record whose [[Type]] is ~normal~ and whose [[Value]] is a Boolean.</dd>
       </dl>
       <emu-alg>
-        1. Assert: Type(_x_) is not Number or BigInt.
         1. Assert: Type(_x_) is the same as Type(_y_).
         1. If Type(_x_) is Undefined, return *true*.
         1. If Type(_x_) is Null, return *true*.

--- a/spec/data-types-and-values.html
+++ b/spec/data-types-and-values.html
@@ -159,8 +159,24 @@
 
     <emu-clause id="sec-ecmascript-language-types-box-type">
       <h1>The Box Type</h1>
-      <p>The Box type is the set of all the possible singleton primitive wrappers around any ECMAScript value. Each box value holds an associated [[Value]] containing an ECMAScript value. The [[Value]] internal slot is never modified.</p>
+      <p>The Box type is the set of all the possible singleton primitive wrappers around any ECMAScript value. Each box value holds an associated [[Value]] containing an ECMAScript value and a [[Realm]] containing the Realm of the Box function which created the Box value. The [[Value]] and [[Realm]] internal slots are never modified.</p>
 
+      <emu-clause id="sec-ecmascript-language-types-box-unbox" type="abstract operation">
+        <h1>
+          Unbox (
+            _box_: a Box,
+          )
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It extracts the boxed Object from _box_, throwing if it has been boxed by a different Realm's Box constructor.</dd>
+        </dl>
+        <emu-alg>
+          1. Let _realm_ be the current Realm Record.
+          1. If _box_.[[Realm]] is not _realm_, throw a TypeError exception.
+          1. Return _box_.[[Value]].
+        </emu-alg>
+      </emu-clause>
 
       <emu-clause id="sec-ecmascript-language-types-box-tostring" type="abstract operation">
         <h1>
@@ -170,7 +186,8 @@
         </h1>
         <dl class="header"></dl>
         <emu-alg>
-          1. Let _valueString_ be ? ToString(_argument_.[[Value]]).
+          1. Let _value_ be ? Unbox(_argument_).
+          1. Let _valueString_ be ? ToString(_value_).
           1. Return the string-concatenation of *"Box("*, _valueString_, and *")"*.
         </emu-alg>
       </emu-clause>
@@ -184,6 +201,7 @@
         </h1>
         <dl class="header"></dl>
         <emu-alg>
+          1. If _x_.[[Realm]] is not _y_.[[Realm]], return *false*.
           1. Let _xValue_ be _x_.[[Value]].
           1. Let _yValue_ be _y_.[[Value]].
           1. Return ! SameValue(_xValue_, _yValue_.)
@@ -199,6 +217,7 @@
         </h1>
         <dl class="header"></dl>
         <emu-alg>
+          1. If _x_.[[Realm]] is not _y_.[[Realm]], return *false*.
           1. Let _xValue_ be _x_.[[Value]].
           1. Let _yValue_ be _y_.[[Value]].
           1. Return ! SameValueZero(_xValue_, _yValue_.)

--- a/spec/data-types-and-values.html
+++ b/spec/data-types-and-values.html
@@ -161,23 +161,6 @@
       <h1>The Box Type</h1>
       <p>The Box type is the set of all the possible singleton primitive wrappers around any ECMAScript value. Each box value holds an associated [[Value]] containing an ECMAScript value and a [[Realm]] containing the Realm of the Box function which created the Box value. The [[Value]] and [[Realm]] internal slots are never modified.</p>
 
-      <emu-clause id="sec-ecmascript-language-types-box-unbox" type="abstract operation">
-        <h1>
-          Unbox (
-            _box_: a Box,
-          )
-        </h1>
-        <dl class="header">
-          <dt>description</dt>
-          <dd>It extracts the boxed Object from _box_, throwing if it has been boxed by a different Realm's Box constructor.</dd>
-        </dl>
-        <emu-alg>
-          1. Let _realm_ be the current Realm Record.
-          1. If _box_.[[Realm]] is not _realm_, throw a TypeError exception.
-          1. Return _box_.[[Value]].
-        </emu-alg>
-      </emu-clause>
-
       <emu-clause id="sec-ecmascript-language-types-box-tostring" type="abstract operation">
         <h1>
           BoxToString (
@@ -186,9 +169,7 @@
         </h1>
         <dl class="header"></dl>
         <emu-alg>
-          1. Let _value_ be ? Unbox(_argument_).
-          1. Let _valueString_ be ? ToString(_value_).
-          1. Return the string-concatenation of *"Box("*, _valueString_, and *")"*.
+          1. Return *"[object Box]"*.
         </emu-alg>
       </emu-clause>
 

--- a/spec/immutable-data-structures.html
+++ b/spec/immutable-data-structures.html
@@ -675,6 +675,15 @@
         </emu-clause>
       </emu-clause>
 
+      <emu-clause id="sec-box.unbox">
+        <h1>Box.unbox ( _value_ )</h1>
+        <p>When the `unbox` function is called, the following steps are taken:</p>
+        <emu-alg>
+          1. Let _box_ be ? thisBoxValue(_value_).
+          1. Return _box_.[[Value]].
+        </emu-alg>
+      </emu-clause>
+
       <emu-clause id="sec-box.prototype">
         <h1>Box.prototype</h1>
         <p>The initial value of *Box.prototype* is %Box.prototype%</p>
@@ -714,14 +723,6 @@
         <h1>Box.prototype [ @@toStringTag ]</h1>
         <p>The initial value of *Box.prototype[@@toStringTag]* is the String value *"Box"*.</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
-      </emu-clause>
-      <emu-clause id="sec-box.prototype.unbox">
-        <h1>Box.prototype.unbox ( )</h1>
-        <p>When the `unbox` function is called, the following steps are taken:</p>
-        <emu-alg>
-          1. Let _box_ be ? thisBoxValue(*this* value).
-          1. Return _box_.[[Value]]
-        </emu-alg>
       </emu-clause>
     </emu-clause>
   </emu-clause>

--- a/spec/immutable-data-structures.html
+++ b/spec/immutable-data-structures.html
@@ -678,10 +678,12 @@
 
       <emu-clause id="sec-box.unbox">
         <h1>Box.unbox ( _value_ )</h1>
-        <p>When the `unbox` function is called, the following steps are taken:</p>
+        <p>The `unbox` function extracts the wrapped ECMAScript language value from _box_, throwing if it has been wrapped by a different Realm's Box constructor. When called, the following steps are taken:</p>
         <emu-alg>
           1. Let _box_ be ? thisBoxValue(_value_).
-          1. Return ? Unbox(_box_).
+          1. Let _realm_ be the current Realm Record.
+          1. If _box_.[[Realm]] is not _realm_, throw a TypeError exception.
+          1. Return _box_.[[Value]].
         </emu-alg>
       </emu-clause>
 

--- a/spec/immutable-data-structures.html
+++ b/spec/immutable-data-structures.html
@@ -637,7 +637,8 @@
         <p>When the `Box` function is called, the following steps are taken:</p>
         <emu-alg>
           1. If NewTarget is not *undefined*, throw a *TypeError* exception.
-          1. Return a new Box value whose [[Value]] is _arg_.
+          1. Let _realm_ be the current Realm Record.
+          1. Return a new Box value whose [[Value]] is _arg_ and whose [[Realm]] is _realm_.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -680,7 +681,7 @@
         <p>When the `unbox` function is called, the following steps are taken:</p>
         <emu-alg>
           1. Let _box_ be ? thisBoxValue(_value_).
-          1. Return _box_.[[Value]].
+          1. Return ? Unbox(_box_).
         </emu-alg>
       </emu-clause>
 

--- a/spec/ordinary-and-exotic-object-behaviours.html
+++ b/spec/ordinary-and-exotic-object-behaviours.html
@@ -378,7 +378,7 @@
 
     <emu-clause id="sec-box-exitic-objects">
       <h1>Box Exotic Objects</h1>
-      <p>A Box object is an exotic object that encapsuates a Box value and exposes virtual integer-indexed data properties corresponding to the individual entries set on the underlying Box value. All keys properties are non-writable and non-configurable.</p>
+      <p>A Box object is an exotic object that encapsulates a Box value. It doesn't have any own key.</p>
 
       <p>An object is a <dfn id="box-exotic-object">Box exotic object</dfn> (or simply, a Box object) if its following internal methods use the following implementations and it is an <emu-xref href="#sec-immutable-prototype-exotic-objects">Immutable Prototype Exotic Object</emu-xref>.</p>
 

--- a/spec/structured-data.html
+++ b/spec/structured-data.html
@@ -143,15 +143,15 @@
               1. <ins>Set _toJSONCalled_ to *true*.</ins>
           1. If _state_.[[ReplacerFunction]] is not *undefined*, then
             1. Set _value_ to ? Call(_state_.[[ReplacerFunction]], _holder_, &laquo; _key_, _value_ &raquo;).
-            1. <ins>Set _value_ to ! MaybeUnwrapBox(_value_).</ins>
+            1. <ins>Set _value_ to ? MaybeUnwrapBox(_value_).</ins>
           1. <ins>Else,</ins>
-            1. <ins>Set _value_ to ! MaybeUnwrapBox(_value_).</ins>
+            1. <ins>Set _value_ to ? MaybeUnwrapBox(_value_).</ins>
             1. <ins>If _toJSONCalled_ is *false*, then</ins>
               1. <ins>If Type(_value_) is Object or BigInt, then</ins>
               1. <ins>Let _toJSON_ be ? GetV(_value_, *"toJSON"*).</ins>
               1. <ins>If IsCallable(_toJSON_) is *true*, then</ins>
                 1. <ins>Set _value_ to ? Call(_toJSON_, _value_, &laquo; _key_ &raquo;).</ins>
-                1. <ins>Set _value_ to ! MaybeUnwrapBox(_value_).</ins>
+                1. <ins>Set _value_ to ? MaybeUnwrapBox(_value_).</ins>
           1. If Type(_value_) is Object, then
             1. If _value_ has a [[NumberData]] internal slot, then
               1. Set _value_ to ? ToNumber(_value_).
@@ -192,7 +192,7 @@
         <emu-alg>
           1. If Type(_value_) is Object and _value_ has a [[BoxData]] internal slot,
             1. Set _value_ to _value_.[[BoxData]].
-          1. If Type(_value_) is Box, return ! MaybeUnwrapBox(_value_.[[Value]]).
+          1. If Type(_value_) is Box, return ? Unbox(_value_).
           1. Return _value_.
         </emu-alg>
       </emu-clause>

--- a/spec/structured-data.html
+++ b/spec/structured-data.html
@@ -135,23 +135,12 @@
         <dl class="header"></dl>
         <emu-alg>
           1. Let _value_ be ? Get(_holder_, _key_).
-          1. <ins>Let _toJSONCalled_ be *false*.</ins>
-          1. If Type(_value_) is Object or BigInt, then
+          1. If Type(_value_) is Object<ins>, Box,</ins> or BigInt, then
             1. Let _toJSON_ be ? GetV(_value_, *"toJSON"*).
             1. If IsCallable(_toJSON_) is *true*, then
               1. Set _value_ to ? Call(_toJSON_, _value_, &laquo; _key_ &raquo;).
-              1. <ins>Set _toJSONCalled_ to *true*.</ins>
           1. If _state_.[[ReplacerFunction]] is not *undefined*, then
             1. Set _value_ to ? Call(_state_.[[ReplacerFunction]], _holder_, &laquo; _key_, _value_ &raquo;).
-            1. <ins>Set _value_ to ? MaybeUnwrapBox(_value_).</ins>
-          1. <ins>Else,</ins>
-            1. <ins>Set _value_ to ? MaybeUnwrapBox(_value_).</ins>
-            1. <ins>If _toJSONCalled_ is *false*, then</ins>
-              1. <ins>If Type(_value_) is Object or BigInt, then</ins>
-              1. <ins>Let _toJSON_ be ? GetV(_value_, *"toJSON"*).</ins>
-              1. <ins>If IsCallable(_toJSON_) is *true*, then</ins>
-                1. <ins>Set _value_ to ? Call(_toJSON_, _value_, &laquo; _key_ &raquo;).</ins>
-                1. <ins>Set _value_ to ? MaybeUnwrapBox(_value_).</ins>
           1. If Type(_value_) is Object, then
             1. If _value_ has a [[NumberData]] internal slot, then
               1. Set _value_ to ? ToNumber(_value_).
@@ -169,7 +158,7 @@
           1. If Type(_value_) is Number, then
             1. If _value_ is finite, return ! ToString(_value_).
             1. Return *"null"*.
-          1. If Type(_value_) is BigInt, throw a *TypeError* exception.
+          1. If Type(_value_) is BigInt <ins>or Box</ins>, throw a *TypeError* exception.
           1. If Type(_value_) is Object and IsCallable(_value_) is *false*, then
             1. <del>Let _isArray_ be ? IsArray(_value_).</del>
             1. <ins>If ! IsTuple(_value_) is *true*, then</ins>
@@ -179,21 +168,6 @@
             1. If <del>_isArray_</del><ins>_isArrayLike_</ins> is *true*, return ? SerializeJSONArray(_state_, _value_).
             1. Return ? SerializeJSONObject(_state_, _value_).
           1. Return *undefined*.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-maybeunwrapbox" type="abstract operation">
-        <h1>
-          <ins>MaybeUnwrapBox</ins> (
-            _value_: an ECMAScript language value,
-          )
-        </h1>
-        <dl class="header"></dl>
-        <emu-alg>
-          1. If Type(_value_) is Object and _value_ has a [[BoxData]] internal slot,
-            1. Set _value_ to _value_.[[BoxData]].
-          1. If Type(_value_) is Box, return ? Unbox(_value_).
-          1. Return _value_.
         </emu-alg>
       </emu-clause>
     </emu-clause>


### PR DESCRIPTION
- Fix https://github.com/tc39/proposal-record-tuple/issues/255
- Make `.unbox` a static method
- ~~Disallow primitives in boxes~~ (https://github.com/tc39/proposal-record-tuple/issues/258)
- Add the realm check
- Don't automatically unwrap boxes in `JSON.stringify`, similarly to how `BigInt`s aren't automatically serialized