### PR TITLE
Expand R&T support across methods that accept objects and arrays

### DIFF
--- a/spec/abstract-operations.html
+++ b/spec/abstract-operations.html
@@ -1024,22 +1024,5 @@
         1. Return _ret_.
       </emu-alg>
     </emu-clause>
-
-    <emu-clause id="sec-isconcatspreadable" type="abstract operation">
-      <h1>
-        IsConcatSpreadable (
-          _O_: unknown,
-        ): either a normal completion containing a Boolean or a throw completion
-      </h1>
-      <dl class="header">
-      </dl>
-      <emu-alg>
-        1. If Type(_O_) is not Object or Tuple, return *false*.
-        1. Let _spreadable_ be ? Get<ins>V</ins>(_O_, @@isConcatSpreadable).
-        1. If _spreadable_ is not *undefined*, return ToBoolean(_spreadable_).
-        1. <ins>If IsTuple(_O_), return *true*.</ins>
-        1. Return ? IsArray(_O_).
-      </emu-alg>
-    </emu-clause>
   </emu-clause>
 </emu-clause>

--- a/spec/abstract-operations.html
+++ b/spec/abstract-operations.html
@@ -1024,5 +1024,19 @@
         1. Return _ret_.
       </emu-alg>
     </emu-clause>
+
+    <emu-clause id="sec-isarrayortuple" type="abstract operation">
+      <h1>
+        IsArrayOrTuple (
+          _O_: an ECMAScript language value,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
+      <emu-alg>
+        1. If IsTuple(_O_), return *true*.
+        1. Return ? IsArray(_O_).
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 </emu-clause>

--- a/spec/expression.html
+++ b/spec/expression.html
@@ -349,8 +349,8 @@
         1. <ins>If Type(_rval_) is Tuple, return *false*.</ins>
         1. If Type(_rval_) is not Object, throw a *TypeError* exception.
         1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
-        1. Let _privateName_ be ! ResolvePrivateIdentifier(_privateEnv_, _privateIdentifier_).
-        1. If ! PrivateElementFind(_rval_, _privateName_) is not ~empty~, return *true*.
+        1. Let _privateName_ be ResolvePrivateIdentifier(_privateEnv_, _privateIdentifier_).
+        1. If PrivateElementFind(_rval_, _privateName_) is not ~empty~, return *true*.
         1. Return *false*.
       </emu-alg>
     </emu-clause>

--- a/spec/expression.html
+++ b/spec/expression.html
@@ -331,9 +331,9 @@
 
       <emu-grammar>RelationalExpression : RelationalExpression `in` ShiftExpression</emu-grammar>
       <emu-alg>
-        1. Let _lref_ be the result of evaluating |RelationalExpression|.
+        1. Let _lref_ be ? Evaluation of |RelationalExpression|.
         1. Let _lval_ be ? GetValue(_lref_).
-        1. Let _rref_ be the result of evaluating |ShiftExpression|.
+        1. Let _rref_ be ? Evaluation of |ShiftExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. <ins>If Type(_rval_) is Record, set _rval_ to ! ToObject(_rval_).</ins>
         1. <ins>If Type(_rval_) is Tuple, set _rval_ to ! ToObject(_rval_).</ins>
@@ -343,7 +343,7 @@
       <emu-grammar>RelationalExpression : PrivateIdentifier `in` ShiftExpression</emu-grammar>
       <emu-alg>
         1. Let _privateIdentifier_ be the StringValue of |PrivateIdentifier|.
-        1. Let _rref_ be the result of evaluating |ShiftExpression|.
+        1. Let _rref_ be ? Evaluation of |ShiftExpression|.
         1. Let _rval_ be ? GetValue(_rref_).
         1. <ins>If Type(_rval_) is Record, return *false*.</ins>
         1. <ins>If Type(_rval_) is Tuple, return *false*.</ins>

--- a/spec/expression.html
+++ b/spec/expression.html
@@ -323,4 +323,36 @@
       </emu-clause>
     </emu-clause>
   </emu-clause>
+
+  <emu-clause number="10" id="sec-relational-operators">
+    <h1>Relational Operators</h1>
+    <emu-clause id="sec-relational-operators-runtime-semantics-evaluation">
+      <h1>Runtime Semantics: Evaluation</h1>
+
+      <emu-grammar>RelationalExpression : RelationalExpression `in` ShiftExpression</emu-grammar>
+      <emu-alg>
+        1. Let _lref_ be the result of evaluating |RelationalExpression|.
+        1. Let _lval_ be ? GetValue(_lref_).
+        1. Let _rref_ be the result of evaluating |ShiftExpression|.
+        1. Let _rval_ be ? GetValue(_rref_).
+        1. <ins>If Type(_rval_) is Record, set _rval_ to ! ToObject(_rval_).</ins>
+        1. <ins>If Type(_rval_) is Tuple, set _rval_ to ! ToObject(_rval_).</ins>
+        1. If Type(_rval_) is not Object, throw a *TypeError* exception.
+        1. Return ? HasProperty(_rval_, ? ToPropertyKey(_lval_)).
+      </emu-alg>
+      <emu-grammar>RelationalExpression : PrivateIdentifier `in` ShiftExpression</emu-grammar>
+      <emu-alg>
+        1. Let _privateIdentifier_ be the StringValue of |PrivateIdentifier|.
+        1. Let _rref_ be the result of evaluating |ShiftExpression|.
+        1. Let _rval_ be ? GetValue(_rref_).
+        1. <ins>If Type(_rval_) is Record, return *false*.</ins>
+        1. <ins>If Type(_rval_) is Tuple, return *false*.</ins>
+        1. If Type(_rval_) is not Object, throw a *TypeError* exception.
+        1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
+        1. Let _privateName_ be ! ResolvePrivateIdentifier(_privateEnv_, _privateIdentifier_).
+        1. If ! PrivateElementFind(_rval_, _privateName_) is not ~empty~, return *true*.
+        1. Return *false*.
+      </emu-alg>
+    </emu-clause>
+  </emu-clause>
 </emu-clause>

--- a/spec/immutable-data-structures.html
+++ b/spec/immutable-data-structures.html
@@ -269,6 +269,7 @@
             1. Remove the first element from _items_ and let _E_ be the value of the element.
             1. Let _spreadable_ be ? IsConcatSpreadable(_E_).
             1. If _spreadable_ is *true*, then
+              1. Set _E_ to ! ToObject(_E_).
               1. Let _k_ be 0.
               1. Let _len_ be ? LengthOfArrayLike(_E_).
               1. If _n_ + _len_ &gt; 2<sup>53</sup> - 1, throw a *TypeError* exception.

--- a/spec/miscellaneous-updates.html
+++ b/spec/miscellaneous-updates.html
@@ -564,4 +564,28 @@
     </emu-clause>
   </emu-clause>
 
+  <emu-clause id="sec-abstract-operations-for-error-objects">
+    <h1>Miscellaneous updates to Abstract Operations for Error Objects</h1>
+
+    <emu-clause id="sec-installerrorcause" type="abstract operation">
+      <h1>
+        InstallErrorCause (
+          _O_: an Object,
+          _options_: an ECMAScript language value,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It is used to create a *"cause"* property on _O_ when a *"cause"* property is present on _options_.</dd>
+      </dl>
+      <emu-alg>
+        1. <ins>If Type(_options_) is Record, set _options_ to ! ToObject(_options_).</ins>
+        1. If Type(_options_) is Object and ? HasProperty(_options_, *"cause"*) is *true*, then
+          1. Let _cause_ be ? Get(_options_, *"cause"*).
+          1. Perform ! CreateNonEnumerableDataPropertyOrThrow(_O_, *"cause"*, _cause_).
+        1. Return NormalCompletion(*undefined*).
+      </emu-alg>
+    </emu-clause>
+  </emu-clause>
+
 </emu-clause>

--- a/spec/miscellaneous-updates.html
+++ b/spec/miscellaneous-updates.html
@@ -7,6 +7,50 @@
 
   <p>This section contains minor spec updates to different algorithms that are not directly related to Records and Tuples, but they make it easier to interact with them by allowing Records and Tuples to be passed in places of Objects and Arrays.</p>
 
+  <emu-clause id="sec-topropertydescriptor" type="abstract operation">
+    <h1>
+      ToPropertyDescriptor (
+        _Obj_: unknown,
+      )
+    </h1>
+    <dl class="header">
+    </dl>
+    <emu-alg>
+      1. <ins>If Type(_Obj_) is Record, set _Obj_ to ! ToObject(_Obj_).</ins>
+      1. <ins>Else</ins> if Type(_Obj_) is not Object, throw a *TypeError* exception.
+      1. Let _desc_ be a new Property Descriptor that initially has no fields.
+      1. Let _hasEnumerable_ be ? HasProperty(_Obj_, *"enumerable"*).
+      1. If _hasEnumerable_ is *true*, then
+        1. Let _enumerable_ be ! ToBoolean(? Get(_Obj_, *"enumerable"*)).
+        1. Set _desc_.[[Enumerable]] to _enumerable_.
+      1. Let _hasConfigurable_ be ? HasProperty(_Obj_, *"configurable"*).
+      1. If _hasConfigurable_ is *true*, then
+        1. Let _configurable_ be ! ToBoolean(? Get(_Obj_, *"configurable"*)).
+        1. Set _desc_.[[Configurable]] to _configurable_.
+      1. Let _hasValue_ be ? HasProperty(_Obj_, *"value"*).
+      1. If _hasValue_ is *true*, then
+        1. Let _value_ be ? Get(_Obj_, *"value"*).
+        1. Set _desc_.[[Value]] to _value_.
+      1. Let _hasWritable_ be ? HasProperty(_Obj_, *"writable"*).
+      1. If _hasWritable_ is *true*, then
+        1. Let _writable_ be ! ToBoolean(? Get(_Obj_, *"writable"*)).
+        1. Set _desc_.[[Writable]] to _writable_.
+      1. Let _hasGet_ be ? HasProperty(_Obj_, *"get"*).
+      1. If _hasGet_ is *true*, then
+        1. Let _getter_ be ? Get(_Obj_, *"get"*).
+        1. If IsCallable(_getter_) is *false* and _getter_ is not *undefined*, throw a *TypeError* exception.
+        1. Set _desc_.[[Get]] to _getter_.
+      1. Let _hasSet_ be ? HasProperty(_Obj_, *"set"*).
+      1. If _hasSet_ is *true*, then
+        1. Let _setter_ be ? Get(_Obj_, *"set"*).
+        1. If IsCallable(_setter_) is *false* and _setter_ is not *undefined*, throw a *TypeError* exception.
+        1. Set _desc_.[[Set]] to _setter_.
+      1. If _desc_.[[Get]] is present or _desc_.[[Set]] is present, then
+        1. If _desc_.[[Value]] is present or _desc_.[[Writable]] is present, throw a *TypeError* exception.
+      1. Return _desc_.
+    </emu-alg>
+  </emu-clause>
+
   <emu-clause id="sec-createlistfromarraylike" type="abstract operation">
     <h1>
       CreateListFromArrayLike (

--- a/spec/miscellaneous-updates.html
+++ b/spec/miscellaneous-updates.html
@@ -53,8 +53,7 @@
         1. If Type(_O_) is not Object <ins>or Tuple</ins>, return *false*.
         1. Let _spreadable_ be ? Get<ins>V</ins>(_O_, @@isConcatSpreadable).
         1. If _spreadable_ is not *undefined*, return ToBoolean(_spreadable_).
-        1. <ins>If ! IsTuple(_O_), return *true*.</ins>
-        1. If ? IsArray(_O_).
+        1. If ? <del>IsArray</del><ins>IsArrayOrTuple</ins>(_O_).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -89,8 +88,7 @@
               1. Set _element_ to ? Call(_mapperFunction_, _thisArg_, &laquo; _element_, _sourceIndex_, _source_ &raquo;).
             1. Let _shouldFlatten_ be *false*.
             1. If _depth_ &gt; 0, then
-              1. <ins>If ! IsTuple(_element_) is *true*, set _shouldFlatten_ to *true*.</ins>
-              1. <ins>Else,</ins> set _shouldFlatten_ to ? IsArray(_element_).
+              1. Set _shouldFlatten_ to ? <del>IsArray</del><ins>IsArrayOrTuple</ins>(_element_).
             1. If _shouldFlatten_ is *true*, then
               1. If _depth_ is +&infin;, let _newDepth_ be +&infin;.
               1. Else, let _newDepth_ be _depth_ - 1.

--- a/spec/miscellaneous-updates.html
+++ b/spec/miscellaneous-updates.html
@@ -130,4 +130,301 @@
     </emu-clause>
   </emu-clause>
 
+  <emu-clause id="src-miscellaneous-updates-iterators">
+    <h1>Miscellaneous updates to Iterators</h1>
+
+    <p>The updates in this section are all needed to allow iterator methods to return `#{ done, value }` records.</p>
+
+    <emu-clause id="src-unwrapiteratorresult" type="abstract operation">
+      <h1>
+        <ins>UnwrapIteratorResult</ins> (
+          _result_: an ECMAScript value
+        )
+      </h1>
+      <dl class="header">
+      </dl>
+      <emu-alg>
+        1. If Type(_value_) is Record, return ! ToObject(_value_).
+        1. If Type(_value_) is Object, return _value_.
+        1. Throw a *TypeError* exception.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-iteratornext" type="abstract operation">
+      <h1>
+        IteratorNext (
+          _iteratorRecord_: unknown,
+          optional _value_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
+      <emu-alg>
+        1. If _value_ is not present, then
+          1. Let _result_ be ? Call(_iteratorRecord_.[[NextMethod]], _iteratorRecord_.[[Iterator]]).
+        1. Else,
+          1. Let _result_ be ? Call(_iteratorRecord_.[[NextMethod]], _iteratorRecord_.[[Iterator]], &laquo; _value_ &raquo;).
+        1. <ins>Return ? UnwrapIteratorResult(_result_).</ins>
+        1. <del>If Type(_result_) is not Object, throw a *TypeError* exception.</del>
+        1. <del>Return _result_.</del>
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-iteratorclose" type="abstract operation">
+      <h1>
+        IteratorClose (
+          _iteratorRecord_: unknown,
+          _completion_: a Completion Record,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It is used to notify an iterator that it should perform any actions it would normally perform when it has reached its completed state.</dd>
+      </dl>
+      <emu-alg>
+        1. Assert: Type(_iteratorRecord_.[[Iterator]]) is Object.
+        1. Let _iterator_ be _iteratorRecord_.[[Iterator]].
+        1. Let _innerResult_ be GetMethod(_iterator_, *"return"*).
+        1. If _innerResult_.[[Type]] is ~normal~, then
+          1. Let _return_ be _innerResult_.[[Value]].
+          1. If _return_ is *undefined*, return Completion(_completion_).
+          1. Set _innerResult_ to Call(_return_, _iterator_).
+        1. If _completion_.[[Type]] is ~throw~, return Completion(_completion_).
+        1. If _innerResult_.[[Type]] is ~throw~, return Completion(_innerResult_).
+        1. If Type(_innerResult_.[[Value]]) is not Object <ins>or Record</ins>, throw a *TypeError* exception.
+        1. Return Completion(_completion_).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-asynciteratorclose" type="abstract operation">
+      <h1>
+        AsyncIteratorClose (
+          _iteratorRecord_: unknown,
+          _completion_: a Completion Record,
+        )
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It is used to notify an async iterator that it should perform any actions it would normally perform when it has reached its completed state.</dd>
+      </dl>
+      <emu-alg>
+        1. Assert: Type(_iteratorRecord_.[[Iterator]]) is Object.
+        1. Let _iterator_ be _iteratorRecord_.[[Iterator]].
+        1. Let _innerResult_ be GetMethod(_iterator_, *"return"*).
+        1. If _innerResult_.[[Type]] is ~normal~, then
+          1. Let _return_ be _innerResult_.[[Value]].
+          1. If _return_ is *undefined*, return Completion(_completion_).
+          1. Set _innerResult_ to Call(_return_, _iterator_).
+          1. If _innerResult_.[[Type]] is ~normal~, set _innerResult_ to Await(_innerResult_.[[Value]]).
+        1. If _completion_.[[Type]] is ~throw~, return Completion(_completion_).
+        1. If _innerResult_.[[Type]] is ~throw~, return Completion(_innerResult_).
+        1. If Type(_innerResult_.[[Value]]) is not Object <ins>or Record</ins>, throw a *TypeError* exception.
+        1. Return Completion(_completion_).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-%asyncfromsynciteratorprototype%-object">
+      <h1>The %AsyncFromSyncIteratorPrototype% Object</h1>
+
+      <emu-clause id="sec-%asyncfromsynciteratorprototype%.return">
+        <h1>%AsyncFromSyncIteratorPrototype%.return ( [ _value_ ] )</h1>
+
+        <emu-alg>
+          1. Let _O_ be the *this* value.
+          1. Assert: _O_ is an Object that has a [[SyncIteratorRecord]] internal slot.
+          1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+          1. Let _syncIterator_ be _O_.[[SyncIteratorRecord]].[[Iterator]].
+          1. Let _return_ be GetMethod(_syncIterator_, *"return"*).
+          1. IfAbruptRejectPromise(_return_, _promiseCapability_).
+          1. If _return_ is *undefined*, then
+            1. Let _iterResult_ be ! CreateIterResultObject(_value_, *true*).
+            1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _iterResult_ &raquo;).
+            1. Return _promiseCapability_.[[Promise]].
+          1. If _value_ is present, then
+            1. Let _result_ be Call(_return_, _syncIterator_, &laquo; _value_ &raquo;).
+          1. Else,
+            1. Let _result_ be Call(_return_, _syncIterator_).
+          1. IfAbruptRejectPromise(_result_, _promiseCapability_).
+          1. <del>If Type(_result_) is not Object, then</del>
+            1. <del>Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).</del>
+            1. <del>Return _promiseCapability_.[[Promise]].</del>
+          1. <ins>Set _result_ to UnwrapIteratorResult(_result_).</ins>
+          1. <ins>IfAbruptRejectPromise(_result_, _promiseCapability_).</ins>
+          1. Return ! AsyncFromSyncIteratorContinuation(_result_, _promiseCapability_).
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-%asyncfromsynciteratorprototype%.throw">
+        <h1>%AsyncFromSyncIteratorPrototype%.throw ( [ _value_ ] )</h1>
+
+        <emu-alg>
+          1. Let _O_ be the *this* value.
+          1. Assert: _O_ is an Object that has a [[SyncIteratorRecord]] internal slot.
+          1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
+          1. Let _syncIterator_ be _O_.[[SyncIteratorRecord]].[[Iterator]].
+          1. Let _throw_ be GetMethod(_syncIterator_, *"throw"*).
+          1. IfAbruptRejectPromise(_throw_, _promiseCapability_).
+          1. If _throw_ is *undefined*, then
+            1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _value_ &raquo;).
+            1. Return _promiseCapability_.[[Promise]].
+          1. If _value_ is present, then
+            1. Let _result_ be Call(_throw_, _syncIterator_, &laquo; _value_ &raquo;).
+          1. Else,
+            1. Let _result_ be Call(_throw_, _syncIterator_).
+          1. IfAbruptRejectPromise(_result_, _promiseCapability_).
+          1. <del>If Type(_result_) is not Object, then</del>
+            1. <del>Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; a newly created *TypeError* object &raquo;).</del>
+            1. <del>Return _promiseCapability_.[[Promise]].</del>
+          1. <ins>Set _result_ to UnwrapIteratorResult(_result_).</ins>
+          1. <ins>IfAbruptRejectPromise(_result_, _promiseCapability_).</ins>
+          1. Return ! AsyncFromSyncIteratorContinuation(_result_, _promiseCapability_).
+        </emu-alg>
+      </emu-clause>
+    </emu-clause>
+
+    <emu-clause id="sec-generator-function-definitions">
+      <h1>Generator Function Definitions</h1>
+
+      <emu-clause id="sec-generator-function-definitions-runtime-semantics-evaluation">
+        <h1>Runtime Semantics: Evaluation</h1>
+        <emu-grammar>YieldExpression : `yield` `*` AssignmentExpression</emu-grammar>
+        <emu-alg>
+          1. Let _generatorKind_ be ! GetGeneratorKind().
+          1. Let _exprRef_ be the result of evaluating |AssignmentExpression|.
+          1. Let _value_ be ? GetValue(_exprRef_).
+          1. Let _iteratorRecord_ be ? GetIterator(_value_, _generatorKind_).
+          1. Let _iterator_ be _iteratorRecord_.[[Iterator]].
+          1. Let _received_ be NormalCompletion(*undefined*).
+          1. Repeat,
+            1. If _received_.[[Type]] is ~normal~, then
+              1. Let _innerResult_ be ? Call(_iteratorRecord_.[[NextMethod]], _iteratorRecord_.[[Iterator]], &laquo; _received_.[[Value]] &raquo;).
+              1. If _generatorKind_ is ~async~, set _innerResult_ to ? Await(_innerResult_).
+              1. <del>If Type(_innerResult_) is not Object, throw a *TypeError* exception.</del>
+              1. <ins>Set _innerResult_ to ? UnwrapIteratorResult(_innerResult_).</ins>
+              1. Let _done_ be ? IteratorComplete(_innerResult_).
+              1. If _done_ is *true*, then
+                1. Return ? IteratorValue(_innerResult_).
+              1. If _generatorKind_ is ~async~, set _received_ to AsyncGeneratorYield(? IteratorValue(_innerResult_)).
+              1. Else, set _received_ to GeneratorYield(_innerResult_).
+            1. Else if _received_.[[Type]] is ~throw~, then
+              1. Let _throw_ be ? GetMethod(_iterator_, *"throw"*).
+              1. If _throw_ is not *undefined*, then
+                1. Let _innerResult_ be ? Call(_throw_, _iterator_, &laquo; _received_.[[Value]] &raquo;).
+                1. If _generatorKind_ is ~async~, set _innerResult_ to ? Await(_innerResult_).
+                1. NOTE: Exceptions from the inner iterator `throw` method are propagated. Normal completions from an inner `throw` method are processed similarly to an inner `next`.
+                1. <del>If Type(_innerResult_) is not Object, throw a *TypeError* exception.</del>
+                1. <ins>Set _innerResult_ to ? UnwrapIteratorResult(_innerResult_).</ins>
+                1. Let _done_ be ? IteratorComplete(_innerResult_).
+                1. If _done_ is *true*, then
+                  1. Return ? IteratorValue(_innerResult_).
+                1. If _generatorKind_ is ~async~, set _received_ to AsyncGeneratorYield(? IteratorValue(_innerResult_)).
+                1. Else, set _received_ to GeneratorYield(_innerResult_).
+              1. Else,
+                1. NOTE: If _iterator_ does not have a `throw` method, this throw is going to terminate the `yield*` loop. But first we need to give _iterator_ a chance to clean up.
+                1. Let _closeCompletion_ be Completion { [[Type]]: ~normal~, [[Value]]: ~empty~, [[Target]]: ~empty~ }.
+                1. If _generatorKind_ is ~async~, perform ? AsyncIteratorClose(_iteratorRecord_, _closeCompletion_).
+                1. Else, perform ? IteratorClose(_iteratorRecord_, _closeCompletion_).
+                1. NOTE: The next step throws a *TypeError* to indicate that there was a `yield*` protocol violation: _iterator_ does not have a `throw` method.
+                1. Throw a *TypeError* exception.
+            1. Else,
+              1. Assert: _received_.[[Type]] is ~return~.
+              1. Let _return_ be ? GetMethod(_iterator_, *"return"*).
+              1. If _return_ is *undefined*, then
+                1. If _generatorKind_ is ~async~, set _received_.[[Value]] to ? Await(_received_.[[Value]]).
+                1. Return Completion(_received_).
+              1. Let _innerReturnResult_ be ? Call(_return_, _iterator_, &laquo; _received_.[[Value]] &raquo;).
+              1. If _generatorKind_ is ~async~, set _innerReturnResult_ to ? Await(_innerReturnResult_).
+              1. <del>If Type(_innerReturnResult_) is not Object, throw a *TypeError* exception.</del>
+              1. <ins>Set _innerReturnResult_ to ? UnwrapIteratorResult(_innerReturnResult_).</ins>
+              1. Let _done_ be ? IteratorComplete(_innerReturnResult_).
+              1. If _done_ is *true*, then
+                1. Let _value_ be ? IteratorValue(_innerReturnResult_).
+                1. Return Completion { [[Type]]: ~return~, [[Value]]: _value_, [[Target]]: ~empty~ }.
+              1. If _generatorKind_ is ~async~, set _received_ to AsyncGeneratorYield(? IteratorValue(_innerReturnResult_)).
+              1. Else, set _received_ to GeneratorYield(_innerReturnResult_).
+        </emu-alg>
+      </emu-clause>
+    </emu-clause>
+
+    <emu-clause id="sec-runtime-semantics-forin-div-ofbodyevaluation-lhs-stmt-iterator-lhskind-labelset" type="abstract operation">
+      <h1>
+        ForIn/OfBodyEvaluation (
+          _lhs_: unknown,
+          _stmt_: unknown,
+          _iteratorRecord_: unknown,
+          _iterationKind_: unknown,
+          _lhsKind_: either ~assignment~, ~varBinding~ or ~lexicalBinding~,
+          _labelSet_: unknown,
+          optional _iteratorKind_: either ~sync~ or ~async~,
+        )
+      </h1>
+      <emu-alg>
+        1. If _iteratorKind_ is not present, set _iteratorKind_ to ~sync~.
+        1. Let _oldEnv_ be the running execution context's LexicalEnvironment.
+        1. Let _V_ be *undefined*.
+        1. Let _destructuring_ be IsDestructuring of _lhs_.
+        1. If _destructuring_ is *true* and if _lhsKind_ is ~assignment~, then
+          1. Assert: _lhs_ is a |LeftHandSideExpression|.
+          1. Let _assignmentPattern_ be the |AssignmentPattern| that is covered by _lhs_.
+        1. Repeat,
+          1. Let _nextResult_ be ? Call(_iteratorRecord_.[[NextMethod]], _iteratorRecord_.[[Iterator]]).
+          1. If _iteratorKind_ is ~async~, set _nextResult_ to ? Await(_nextResult_).
+          1. <del>If Type(_nextResult_) is not Object, throw a *TypeError* exception.</del>
+          1. <ins>Set _nextResult_ to ? UnwrapIteratorResult(_nextResult_).</ins>
+          1. Let _done_ be ? IteratorComplete(_nextResult_).
+          1. If _done_ is *true*, return NormalCompletion(_V_).
+          1. Let _nextValue_ be ? IteratorValue(_nextResult_).
+          1. If _lhsKind_ is either ~assignment~ or ~varBinding~, then
+            1. If _destructuring_ is *false*, then
+              1. Let _lhsRef_ be the result of evaluating _lhs_. (It may be evaluated repeatedly.)
+          1. Else,
+            1. Assert: _lhsKind_ is ~lexicalBinding~.
+            1. Assert: _lhs_ is a |ForDeclaration|.
+            1. Let _iterationEnv_ be NewDeclarativeEnvironment(_oldEnv_).
+            1. Perform ForDeclarationBindingInstantiation for _lhs_ passing _iterationEnv_ as the argument.
+            1. Set the running execution context's LexicalEnvironment to _iterationEnv_.
+            1. If _destructuring_ is *false*, then
+              1. Assert: _lhs_ binds a single name.
+              1. Let _lhsName_ be the sole element of BoundNames of _lhs_.
+              1. Let _lhsRef_ be ! ResolveBinding(_lhsName_).
+          1. If _destructuring_ is *false*, then
+            1. If _lhsRef_ is an abrupt completion, then
+              1. Let _status_ be _lhsRef_.
+            1. Else if _lhsKind_ is ~lexicalBinding~, then
+              1. Let _status_ be InitializeReferencedBinding(_lhsRef_, _nextValue_).
+            1. Else,
+              1. Let _status_ be PutValue(_lhsRef_, _nextValue_).
+          1. Else,
+            1. If _lhsKind_ is ~assignment~, then
+              1. Let _status_ be DestructuringAssignmentEvaluation of _assignmentPattern_ with argument _nextValue_.
+            1. Else if _lhsKind_ is ~varBinding~, then
+              1. Assert: _lhs_ is a |ForBinding|.
+              1. Let _status_ be BindingInitialization of _lhs_ with arguments _nextValue_ and *undefined*.
+            1. Else,
+              1. Assert: _lhsKind_ is ~lexicalBinding~.
+              1. Assert: _lhs_ is a |ForDeclaration|.
+              1. Let _status_ be ForDeclarationBindingInitialization of _lhs_ with arguments _nextValue_ and _iterationEnv_.
+          1. If _status_ is an abrupt completion, then
+            1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+            1. If _iteratorKind_ is ~async~, return ? AsyncIteratorClose(_iteratorRecord_, _status_).
+            1. If _iterationKind_ is ~enumerate~, then
+              1. Return _status_.
+            1. Else,
+              1. Assert: _iterationKind_ is ~iterate~.
+              1. Return ? IteratorClose(_iteratorRecord_, _status_).
+          1. Let _result_ be the result of evaluating _stmt_.
+          1. Set the running execution context's LexicalEnvironment to _oldEnv_.
+          1. If LoopContinues(_result_, _labelSet_) is *false*, then
+            1. If _iterationKind_ is ~enumerate~, then
+              1. Return Completion(UpdateEmpty(_result_, _V_)).
+            1. Else,
+              1. Assert: _iterationKind_ is ~iterate~.
+              1. Set _status_ to UpdateEmpty(_result_, _V_).
+              1. If _iteratorKind_ is ~async~, return ? AsyncIteratorClose(_iteratorRecord_, _status_).
+              1. Return ? IteratorClose(_iteratorRecord_, _status_).
+          1. If _result_.[[Value]] is not ~empty~, set _V_ to _result_.[[Value]].
+      </emu-alg>
+    </emu-clause>
+  </emu-clause>
+
 </emu-clause>

--- a/spec/miscellaneous-updates.html
+++ b/spec/miscellaneous-updates.html
@@ -7,6 +7,32 @@
 
   <p>This section contains minor spec updates to different algorithms that are not directly related to Records and Tuples, but they make it easier to interact with them by allowing Records and Tuples to be passed in places of Objects and Arrays.</p>
 
+  <emu-clause id="sec-createlistfromarraylike" type="abstract operation">
+    <h1>
+      CreateListFromArrayLike (
+        _obj_: unknown,
+        optional _elementTypes_: a List of names of ECMAScript Language Types,
+      )
+    </h1>
+    <emu-note type="editor">
+      These changes allow using a Tuple for the arguments list passed to `Function.prototype.apply`, `Reflect.apply` and `Reflect.construct`.
+    </emu-note>
+    <emu-alg>
+      1. If _elementTypes_ is not present, set _elementTypes_ to &laquo; Undefined, Null, Boolean, String, Symbol, Number, BigInt, <ins>Record, Tuple, Box</ins> Object &raquo;.
+      1. <ins>If Type(_obj_) is Tuple, set _obj_ to ! ToObject(_obj_).</ins>
+      1. <ins>Else</ins> if Type(_obj_) is not Object, throw a *TypeError* exception.
+      1. Let _len_ be ? LengthOfArrayLike(_obj_).
+      1. Let _list_ be a new empty List.
+      1. Let _index_ be 0.
+      1. Repeat, while _index_ &lt; _len_,
+        1. Let _indexName_ be ! ToString(𝔽(_index_)).
+        1. Let _next_ be ? Get(_obj_, _indexName_).
+        1. If Type(_next_) is not an element of _elementTypes_, throw a *TypeError* exception.
+        1. Append _next_ as the last element of _list_.
+        1. Set _index_ to _index_ + 1.
+      1. Return _list_.
+    </emu-alg>
+  </emu-clause>
 
   <emu-clause id="sec-array.prototype.concat">
     <h1>Array.prototype.concat ( ..._items_ )</h1>

--- a/spec/miscellaneous-updates.html
+++ b/spec/miscellaneous-updates.html
@@ -153,7 +153,7 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. <ins>If IsType(_O_) is *true*, return *true*.</ins>
+        1. <ins>If IsTuple(_O_) is *true*, return *true*.</ins>
         1. If Type(_O_) is not Object, return *false*.
         1. Let _spreadable_ be ? Get(_O_, @@isConcatSpreadable).
         1. If _spreadable_ is not *undefined*, return ToBoolean(_spreadable_).

--- a/spec/miscellaneous-updates.html
+++ b/spec/miscellaneous-updates.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<meta charset="utf8" />
+
+
+<emu-clause id="sec-miscellaneous-updates">
+  <h1>Miscellaneous Updates</h1>
+
+  <p>This section contains minor spec updates to different algorithms that are not directly related to Records and Tuples, but they make it easier to interact with them by allowing Records and Tuples to be passed in places of Objects and Arrays.</p>
+
+
+  <emu-clause id="sec-array.prototype.concat">
+    <h1>Array.prototype.concat ( ..._items_ )</h1>
+    <p>Returns an array containing the array elements of the object followed by the array elements of each argument.</p>
+    <p>When the `concat` method is called, the following steps are taken:</p>
+    <emu-alg>
+      1. Let _O_ be ? ToObject(*this* value).
+      1. Let _A_ be ? ArraySpeciesCreate(_O_, 0).
+      1. Let _n_ be 0.
+      1. Prepend _O_ to _items_.
+      1. For each element _E_ of _items_, do
+        1. Let _spreadable_ be ? IsConcatSpreadable(_E_).
+        1. If _spreadable_ is *true*, then
+          1. <ins>Set _E_ to ! ToObject(_E_).</ins>
+          1. Let _k_ be 0.
+          1. Let _len_ be ? LengthOfArrayLike(_E_).
+          1. If _n_ + _len_ &gt; 2<sup>53</sup> - 1, throw a *TypeError* exception.
+          1. Repeat, while _k_ &lt; _len_,
+            1. Let _P_ be ! ToString(𝔽(_k_)).
+            1. Let _exists_ be ? HasProperty(_E_, _P_).
+            1. If _exists_ is *true*, then
+              1. Let _subElement_ be ? Get(_E_, _P_).
+              1. Perform ? CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _subElement_).
+            1. Set _n_ to _n_ + 1.
+            1. Set _k_ to _k_ + 1.
+        1. Else,
+          1. NOTE: _E_ is added as a single item rather than spread.
+          1. If _n_ &ge; 2<sup>53</sup> - 1, throw a *TypeError* exception.
+          1. Perform ? CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _E_).
+          1. Set _n_ to _n_ + 1.
+      1. [id="step-array-proto-concat-set-length"] Perform ? Set(_A_, *"length"*, 𝔽(_n_), *true*).
+      1. Return _A_.
+    </emu-alg>
+
+    <emu-clause id="sec-isconcatspreadable" type="abstract operation">
+      <h1>
+        IsConcatSpreadable (
+          _O_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
+      <emu-alg>
+        1. If Type(_O_) is not Object <ins>or Tuple</ins>, return *false*.
+        1. Let _spreadable_ be ? Get<ins>V</ins>(_O_, @@isConcatSpreadable).
+        1. If _spreadable_ is not *undefined*, return ToBoolean(_spreadable_).
+        1. <ins>If ! IsTuple(_O_), return *true*.</ins>
+        1. If ? IsArray(_O_).
+      </emu-alg>
+    </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="sec-array.prototype.flat">
+    <h1>Array.prototype.flat ( [ _depth_ ] )</h1>
+
+    <emu-clause id="sec-flattenintoarray" type="abstract operation">
+      <h1>
+        FlattenIntoArray (
+          _target_: an Object,
+          _source_: an Object <ins>or a Tuple</ins>,
+          _sourceLen_: a non-negative integer,
+          _start_: a non-negative integer,
+          _depth_: a non-negative integer or +&infin;,
+          optional _mapperFunction_: unknown,
+          optional _thisArg_: unknown,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
+      <emu-alg>
+        1. Assert: If _mapperFunction_ is present, then ! IsCallable(_mapperFunction_) is *true*, _thisArg_ is present, and _depth_ is 1.
+        1. Let _targetIndex_ be _start_.
+        1. Let _sourceIndex_ be *+0*<sub>𝔽</sub>.
+        1. Repeat, while ℝ(_sourceIndex_) &lt; _sourceLen_,
+          1. Let _P_ be ! ToString(_sourceIndex_).
+          1. Let _exists_ be ? HasProperty(<del>_source_</del><ins>! ToObject(_source_)</ins>, _P_).
+          1. If _exists_ is *true*, then
+            1. Let _element_ be ? Get<ins>V</ins>(_source_, _P_).
+            1. If _mapperFunction_ is present, then
+              1. Set _element_ to ? Call(_mapperFunction_, _thisArg_, &laquo; _element_, _sourceIndex_, _source_ &raquo;).
+            1. Let _shouldFlatten_ be *false*.
+            1. If _depth_ &gt; 0, then
+              1. <ins>If ! IsTuple(_element_) is *true*, set _shouldFlatten_ to *true*.</ins>
+              1. <ins>Else,</ins> set _shouldFlatten_ to ? IsArray(_element_).
+            1. If _shouldFlatten_ is *true*, then
+              1. If _depth_ is +&infin;, let _newDepth_ be +&infin;.
+              1. Else, let _newDepth_ be _depth_ - 1.
+              1. Let _elementLen_ be ? LengthOfArrayLike(<del>_element_</del><ins>ToObject(_element_)</ins>).
+              1. Set _targetIndex_ to ? FlattenIntoArray(_target_, _element_, _elementLen_, _targetIndex_, _newDepth_).
+            1. Else,
+              1. If _targetIndex_ &ge; 2<sup>53</sup> - 1, throw a *TypeError* exception.
+              1. Perform ? CreateDataPropertyOrThrow(_target_, ! ToString(𝔽(_targetIndex_)), _element_).
+              1. Set _targetIndex_ to _targetIndex_ + 1.
+          1. Set _sourceIndex_ to _sourceIndex_ + *1*<sub>𝔽</sub>.
+        1. Return _targetIndex_.
+      </emu-alg>
+    </emu-clause>
+  </emu-clause>
+
+</emu-clause>

--- a/spec/miscellaneous-updates.html
+++ b/spec/miscellaneous-updates.html
@@ -34,6 +34,39 @@
     </emu-alg>
   </emu-clause>
 
+  <emu-clause id="sec-add-entries-from-iterable" type="abstract operation">
+    <h1>
+      AddEntriesFromIterable (
+        _target_: unknown,
+        _iterable_: an ECMAScript language value, but not *undefined* or *null*,
+        _adder_: a function object,
+      )
+    </h1>
+    <dl class="header">
+      <dt>description</dt>
+      <dd>_adder_ will be invoked, with _target_ as the receiver.</dd>
+    </dl>
+    <emu-alg>
+      1. If IsCallable(_adder_) is *false*, throw a *TypeError* exception.
+      1. Let _iteratorRecord_ be ? GetIterator(_iterable_).
+      1. Repeat,
+        1. Let _next_ be ? IteratorStep(_iteratorRecord_).
+        1. If _next_ is *false*, return _target_.
+        1. Let _nextItem_ be ? IteratorValue(_next_).
+        1. <ins>If Type(_nextItem_) is Tuple, then</ins>
+          1. <ins>Set _nextItem_ to ! ToObject(_nextItem_).</ins>
+        1. <ins>Else</ins> if Type(_nextItem_) is not Object, then
+          1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).
+          1. Return ? IteratorClose(_iteratorRecord_, _error_).
+        1. Let _k_ be Get(_nextItem_, *"0"*).
+        1. IfAbruptCloseIterator(_k_, _iteratorRecord_).
+        1. Let _v_ be Get(_nextItem_, *"1"*).
+        1. IfAbruptCloseIterator(_v_, _iteratorRecord_).
+        1. Let _status_ be Call(_adder_, _target_, &laquo; _k_, _v_ &raquo;).
+        1. IfAbruptCloseIterator(_status_, _iteratorRecord_).
+    </emu-alg>
+  </emu-clause>
+
   <emu-clause id="sec-array.prototype.concat">
     <h1>Array.prototype.concat ( ..._items_ )</h1>
     <p>Returns an array containing the array elements of the object followed by the array elements of each argument.</p>

--- a/spec/miscellaneous-updates.html
+++ b/spec/miscellaneous-updates.html
@@ -153,10 +153,11 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. If Type(_O_) is not Object <ins>or Tuple</ins>, return *false*.
-        1. Let _spreadable_ be ? Get<ins>V</ins>(_O_, @@isConcatSpreadable).
+        1. <ins>If IsType(_O_) is *true*, return *true*.</ins>
+        1. If Type(_O_) is not Object, return *false*.
+        1. Let _spreadable_ be ? Get(_O_, @@isConcatSpreadable).
         1. If _spreadable_ is not *undefined*, return ToBoolean(_spreadable_).
-        1. If ? <del>IsArray</del><ins>IsArrayOrTuple</ins>(_O_).
+        1. If ? IsArray(_O_).
       </emu-alg>
     </emu-clause>
   </emu-clause>

--- a/spec/miscellaneous-updates.html
+++ b/spec/miscellaneous-updates.html
@@ -207,6 +207,66 @@
     </emu-clause>
   </emu-clause>
 
+  <emu-clause id="sec-typedarray" oldids="sec-typedarray-length,sec-typedarray-object">
+    <h1>_TypedArray_ ( ..._args_ )</h1>
+    <p>Each _TypedArray_ constructor performs the following steps when called:</p>
+    <emu-alg>
+      1. If NewTarget is *undefined*, throw a *TypeError* exception.
+      1. Let _constructorName_ be the String value of the Constructor Name value specified in <emu-xref href="#table-the-typedarray-constructors"></emu-xref> for this <var>TypedArray</var> constructor.
+      1. Let _proto_ be <code>"%<var>TypedArray</var>.prototype%"</code>.
+      1. Let _numberOfArgs_ be the number of elements in _args_.
+      1. If _numberOfArgs_ = 0, then
+        1. Return ? AllocateTypedArray(_constructorName_, NewTarget, _proto_, 0).
+      1. Else,
+        1. Let _firstArgument_ be _args_[0].
+        1. <ins>If Type(_firstArg_) is Tuple, then</ins>
+          1. <ins>Let _O_ be ? AllocateTypedArray(_constructorName_, NewTarget, _proto_).</ins>
+          1. <ins>Perform ? InitializeTypedArrayFromTuple(_O_, _firstArg_).</ins>
+        1. <ins>Else</ins> if Type(_firstArgument_) is Object, then
+          1. Let _O_ be ? AllocateTypedArray(_constructorName_, NewTarget, _proto_).
+          1. If _firstArgument_ has a [[TypedArrayName]] internal slot, then
+            1. Perform ? InitializeTypedArrayFromTypedArray(_O_, _firstArgument_).
+          1. Else if _firstArgument_ has an [[ArrayBufferData]] internal slot, then
+            1. If _numberOfArgs_ &gt; 1, let _byteOffset_ be _args_[1]; else let _byteOffset_ be *undefined*.
+            1. If _numberOfArgs_ &gt; 2, let _length_ be _args_[2]; else let _length_ be *undefined*.
+            1. Perform ? InitializeTypedArrayFromArrayBuffer(_O_, _firstArgument_, _byteOffset_, _length_).
+          1. Else,
+            1. Assert: Type(_firstArgument_) is Object and _firstArgument_ does not have either a [[TypedArrayName]] or an [[ArrayBufferData]] internal slot.
+            1. Let _usingIterator_ be ? GetMethod(_firstArgument_, @@iterator).
+            1. If _usingIterator_ is not *undefined*, then
+              1. Let _values_ be ? IterableToList(_firstArgument_, _usingIterator_).
+              1. Perform ? InitializeTypedArrayFromList(_O_, _values_).
+            1. Else,
+              1. NOTE: _firstArgument_ is not an Iterable so assume it is already an array-like object.
+              1. Perform ? InitializeTypedArrayFromArrayLike(_O_, _firstArgument_).
+          1. Return _O_.
+        1. Else,
+          1. Assert: _firstArgument_ is not an Object <ins>or a Tuple</ins>.
+          1. Let _elementLength_ be ? ToIndex(_firstArgument_).
+          1. Return ? AllocateTypedArray(_constructorName_, NewTarget, _proto_, _elementLength_).
+    </emu-alg>
+
+    <emu-clause id="sec-initializetypedarrayfromtuple" type="abstract operation">
+      <h1>
+        <ins>InitializeTypedArrayFromTuple</ins> (
+          _O_: a TypedArray,
+          _tuple_: a Tuple,
+        )
+      </h1>
+      <dl class="header">
+      </dl>
+      <emu-alg>
+        1. Let _len_ be the length of in _tuple_.[[Elements]].
+        1. Perform ? AllocateTypedArrayBuffer(_O_, _len_).
+        1. Let _k_ be 0.
+        1. For each _kValue_ in _tuple_.[[Elements]], do
+          1. Let _Pk_ be ! ToString(𝔽(_k_)).
+          1. Perform ? Set(_O_, _Pk_, _kValue_, *true*).
+          1. Set _k_ to _k_ + 1.
+      </emu-alg>
+    </emu-clause>
+  </emu-clause>
+
   <emu-clause id="src-miscellaneous-updates-iterators">
     <h1>Miscellaneous updates to Iterators</h1>
 

--- a/spec/miscellaneous-updates.html
+++ b/spec/miscellaneous-updates.html
@@ -97,7 +97,7 @@
         1. Let _next_ be ? IteratorStep(_iteratorRecord_).
         1. If _next_ is *false*, return _target_.
         1. Let _nextItem_ be ? IteratorValue(_next_).
-        1. <ins>If Type(_nextItem_) is Tuple, then</ins>
+        1. <ins>If Type(_nextItem_) is Tuple or Record, then</ins>
           1. <ins>Set _nextItem_ to ! ToObject(_nextItem_).</ins>
         1. <ins>Else</ins> if Type(_nextItem_) is not Object, then
           1. Let _error_ be ThrowCompletion(a newly created *TypeError* object).

--- a/spec/miscellaneous-updates.html
+++ b/spec/miscellaneous-updates.html
@@ -59,10 +59,10 @@
       )
     </h1>
     <emu-note type="editor">
-      These changes allow using a Tuple for the arguments list passed to `Function.prototype.apply`, `Reflect.apply` and `Reflect.construct`.
+      These changes allow using a Tuple for the arguments list passed to `Function.prototype.apply`, `Reflect.apply`, and `Reflect.construct`.
     </emu-note>
     <emu-alg>
-      1. If _elementTypes_ is not present, set _elementTypes_ to &laquo; Undefined, Null, Boolean, String, Symbol, Number, BigInt, <ins>Record, Tuple, Box</ins> Object &raquo;.
+      1. If _elementTypes_ is not present, set _elementTypes_ to &laquo; Undefined, Null, Boolean, String, Symbol, Number, BigInt, <ins>Record, Tuple, Box,</ins> Object &raquo;.
       1. <ins>If Type(_obj_) is Tuple, set _obj_ to ! ToObject(_obj_).</ins>
       1. <ins>Else</ins> if Type(_obj_) is not Object, throw a *TypeError* exception.
       1. Let _len_ be ? LengthOfArrayLike(_obj_).

--- a/spec/structured-data.html
+++ b/spec/structured-data.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<meta charset="utf8" />
+
+<emu-clause id="sec-structured-data">
+  <h1>Structured Data</h1>
+
+  <emu-clause number="5" id="sec-json-object">
+    <h1>The JSON Object</h1>
+
+    <emu-clause number="2" id="sec-json.stringify">
+      <h1>JSON.stringify ( _value_ [ , _replacer_ [ , _space_ ] ] )</h1>
+
+      <emu-alg>
+        1. Let _stack_ be a new empty List.
+        1. Let _indent_ be the empty String.
+        1. Let _PropertyList_ and _ReplacerFunction_ be *undefined*.
+        1. If Type(_replacer_) is Object <ins>or Tuple</ins>, then
+          1. If IsCallable(_replacer_) is *true*, then
+            1. Set _ReplacerFunction_ to _replacer_.
+          1. Else,
+            1. Let _isArray_ be ? <del>IsArray</del><ins>IsArrayOrTuple</ins>(_replacer_).
+            1. If _isArray_ is *true*, then
+              1. Set _PropertyList_ to a new empty List.
+              1. Let _len_ be ? LengthOfArrayLike(<del>_replacer_</del><ins>! ToObject(_replacer_)</ins>).
+              1. Let _k_ be 0.
+              1. Repeat, while _k_ &lt; _len_,
+                1. Let _prop_ be ! ToString(𝔽(_k_)).
+                1. Let _v_ be ? <del>Get</del><ins>GetV</ins>(_replacer_, _prop_).
+                1. Let _item_ be *undefined*.
+                1. If Type(_v_) is String, set _item_ to _v_.
+                1. Else if Type(_v_) is Number, set _item_ to ! ToString(_v_).
+                1. Else if Type(_v_) is Object, then
+                  1. If _v_ has a [[StringData]] or [[NumberData]] internal slot, set _item_ to ? ToString(_v_).
+                1. If _item_ is not *undefined* and _item_ is not currently an element of _PropertyList_, then
+                  1. Append _item_ to the end of _PropertyList_.
+                1. Set _k_ to _k_ + 1.
+        1. If Type(_space_) is Object, then
+          1. If _space_ has a [[NumberData]] internal slot, then
+            1. Set _space_ to ? ToNumber(_space_).
+          1. Else if _space_ has a [[StringData]] internal slot, then
+            1. Set _space_ to ? ToString(_space_).
+        1. If Type(_space_) is Number, then
+          1. Let _spaceMV_ be ! ToIntegerOrInfinity(_space_).
+          1. Set _spaceMV_ to min(10, _spaceMV_).
+          1. If _spaceMV_ &lt; 1, let _gap_ be the empty String; otherwise let _gap_ be the String value containing _spaceMV_ occurrences of the code unit 0x0020 (SPACE).
+        1. Else if Type(_space_) is String, then
+          1. If the length of _space_ is 10 or less, let _gap_ be _space_; otherwise let _gap_ be the substring of _space_ from 0 to 10.
+        1. Else,
+          1. Let _gap_ be the empty String.
+        1. Let _wrapper_ be ! OrdinaryObjectCreate(%Object.prototype%).
+        1. Perform ! CreateDataPropertyOrThrow(_wrapper_, the empty String, _value_).
+        1. Let _state_ be the Record { [[ReplacerFunction]]: _ReplacerFunction_, [[Stack]]: _stack_, [[Indent]]: _indent_, [[Gap]]: _gap_, [[PropertyList]]: _PropertyList_ }.
+        1. Return ? SerializeJSONProperty(_state_, the empty String, _wrapper_).
+      </emu-alg>
+
+      <emu-clause number="2" id="sec-serializejsonproperty" type="abstract operation">
+        <h1>
+          SerializeJSONProperty (
+            _state_: unknown,
+            _key_: unknown,
+            _holder_: unknown,
+          )
+        </h1>
+        <dl class="header"></dl>
+        <emu-alg>
+          1. Let _value_ be ? Get(_holder_, _key_).
+          1. If Type(_value_) is Object or BigInt, then
+            1. Let _toJSON_ be ? GetV(_value_, *"toJSON"*).
+            1. If IsCallable(_toJSON_) is *true*, then
+              1. Set _value_ to ? Call(_toJSON_, _value_, &laquo; _key_ &raquo;).
+          1. If _state_.[[ReplacerFunction]] is not *undefined*, then
+            1. Set _value_ to ? Call(_state_.[[ReplacerFunction]], _holder_, &laquo; _key_, _value_ &raquo;).
+          1. If Type(_value_) is Object, then
+            1. If _value_ has a [[NumberData]] internal slot, then
+              1. Set _value_ to ? ToNumber(_value_).
+            1. Else if _value_ has a [[StringData]] internal slot, then
+              1. Set _value_ to ? ToString(_value_).
+            1. Else if _value_ has a [[BooleanData]] internal slot, then
+              1. Set _value_ to _value_.[[BooleanData]].
+            1. Else if _value_ has a [[BigIntData]] internal slot, then
+              1. Set _value_ to _value_.[[BigIntData]].
+          1. If _value_ is *null*, return *"null"*.
+          1. If _value_ is *true*, return *"true"*.
+          1. If _value_ is *false*, return *"false"*.
+          1. <ins>If Type(_value_) is Record or Type(_value_) is Tuple, set _value_ to ! ToObject(_value_).</ins>
+          1. If Type(_value_) is String, return QuoteJSONString(_value_).
+          1. If Type(_value_) is Number, then
+            1. If _value_ is finite, return ! ToString(_value_).
+            1. Return *"null"*.
+          1. If Type(_value_) is BigInt, throw a *TypeError* exception.
+          1. If Type(_value_) is Object and IsCallable(_value_) is *false*, then
+            1. Let <del>_isArray_</del><ins>_isArrayOrTuple_</ins> be ? <del>IsArray</del><ins>IsArrayOrTuple</ins>(_value_).</del>
+            1. If <del>_isArray_</del><ins>_isArrayOrTuple_</ins> is *true*, return ? SerializeJSONArray(_state_, _value_).
+            1. Return ? SerializeJSONObject(_state_, _value_).
+          1. Return *undefined*.
+        </emu-alg>
+      </emu-clause>
+    </emu-clause>
+  </emu-clause>
+</emu-clause>


### PR DESCRIPTION
I didn't add support for:
- `Reflect.*`, since they already disallow primitives even if it would make sense to use them (e.g. `Reflect.get("str", 0)`).
- Proxy handler (`new Proxy(target, #{})`), since it's meant to contain functions so a record would only work as an empty handler.
- ~~`JSON.stringify`'s replacer array, just to avoid conflicts with https://github.com/tc39/proposal-record-tuple/pull/257: I'll do it in a separate PR in the future~~ EDIT: done. ~~There are also a bunch of bugs in the current JSON implementation, where we pass R/T to AOs that expects objects.~~

Closes #107

This PR should be reviewed commit-by-commit. Most algorithms in the `misc-updates.html` file are copied from the existing spec (except for `InitializeTypedArrayFromTuple` and `UnwrapIteratorResult`): focus on the `<ins>` and `<del>` tags.