### PR TITLE
Normative: Use `Symbol.toStringTag` for `Tuple` objects

### DIFF
--- a/spec/fundamental-objects.html
+++ b/spec/fundamental-objects.html
@@ -25,8 +25,6 @@
           1. Else if _O_ has a [[DateValue]] internal slot, let _builtinTag_ be *"Date"*.
           1. Else if _O_ has a [[RegExpMatcher]] internal slot, let _builtinTag_ be *"RegExp"*.
           1. <ins>Else if _O_ has a [[RecordData]] internal slot, let _builtinTag_ be *"Record"*.</ins>
-          1. <ins>Else if _O_ has a [[TupleData]] internal slot, let _builtinTag_ be *"Tuple"*.</ins>
-          1. <ins>Else if _O_ has a [[BoxData]] internal slot, let _builtinTag_ be *"Box"*.</ins>
           1. Else, let _builtinTag_ be *"Object"*.
           1. Let _tag_ be ? Get(_O_, @@toStringTag).
           1. If Type(_tag_) is not String, set _tag_ to _builtinTag_.

--- a/spec/immutable-data-structures.html
+++ b/spec/immutable-data-structures.html
@@ -551,6 +551,12 @@
           1. Return a new Tuple value whose [[Sequence]] is _list_.
         </emu-alg>
       </emu-clause>
+
+      <emu-clause id="sec-reflect-@@tostringtag">
+        <h1>Tuple.prototype [ @@toStringTag ]</h1>
+        <p>The initial value of the @@toStringTag property is the String value *"Tuple"*.</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
+      </emu-clause>
     </emu-clause>
   </emu-clause>
 
@@ -655,6 +661,12 @@
           1. Let _box_ be ? thisBoxValue(*this* value).
           1. Return _box_.[[Value]]
         </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-reflect-@@tostringtag">
+        <h1>Box.prototype [ @@toStringTag ]</h1>
+        <p>The initial value of the @@toStringTag property is the String value *"Box"*.</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
       </emu-clause>
     </emu-clause>
   </emu-clause>


### PR DESCRIPTION
New types shouldn’t be adding new built‑in tags to <code>[Object.prototype.toString()]</code>, which is why <code>[Symbol.toStringTag]</code> was introduced.

[Object.prototype.toString()]: https://tc39.es/ecma262/#sec-object.prototype.tostring
[Symbol.toStringTag]: https://tc39.es/ecma262/#sec-symbol.tostringtag