### PR TITLE
Fix Object.keys(#{ a: 1, b: 2 }) === #["a", "b"]

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ For integrity, out-of-bounds numerical indexing on Tuples returns `undefined`, r
 `Tuple` values have functionality broadly analogous to `Array`. Similarly, `Record` values are supported by different `Object` static methods.
 
 ```js
-assert(Object.keys(#{ a: 1, b: 2 }) !== #["a", "b"]);
+assert.deepEqual(Object.keys(#{ a: 1, b: 2 }), ["a", "b"]);
 assert(#[1, 2, 3].map(x => x * 2), #[2, 4, 6]);
 ```
 

--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ For integrity, out-of-bounds numerical indexing on Tuples returns `undefined`, r
 `Tuple` values have functionality broadly analogous to `Array`. Similarly, `Record` values are supported by different `Object` static methods.
 
 ```js
-assert(Object.keys(#{ a: 1, b: 2 }) === #["a", "b"]);
+assert(Object.keys(#{ a: 1, b: 2 }) !== #["a", "b"]);
 assert(#[1, 2, 3].map(x => x * 2), #[2, 4, 6]);
 ```
 


### PR DESCRIPTION
> assert(Object.keys(#{ a: 1, b: 2 }) === #["a", "b"]);

should be

> assert(Object.keys(#{ a: 1, b: 2 }) !== #["a", "b"]);