### PR TITLE
Rename `master` -> `main` in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 name: Publish the spec & cookbook to gh-pages
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The action isn't currently running