### PR TITLE
Record exotic object [[Delete]] was using `?` for a `!` case

### DIFF
--- a/spec/ordinary-and-exotic-object-behaviours.html
+++ b/spec/ordinary-and-exotic-object-behaviours.html
@@ -102,7 +102,7 @@
         </dl>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
-          1. Let _hasProperty_ ? RecordHasProperty( _R_, _P_ ).
+          1. Let _hasProperty_ ! RecordHasProperty( _R_, _P_ ).
           1. If _hasProperty_ is *false*, return *true*.
           1. Return *false*.
         </emu-alg>


### PR DESCRIPTION
AFAICT, RecordHasProperty cannot throw and other places where it gets invoked already use `!`.