### PR TITLE
Update marked import

### DIFF
--- a/scripts/build-static-page.mjs
+++ b/scripts/build-static-page.mjs
@@ -1,6 +1,6 @@
 // @ts-check
 import fse from "fs-extra";
-import marked from "marked";
+import { marked } from "marked";
 import { join } from "path";
 
 async function buildLanguageFile(lang, config, isDefault = false) {


### PR DESCRIPTION
Marked was recently updated to v4 in the dependencies, but the code wasn't updated

Makes the tests pass: https://github.com/tc39/proposal-record-tuple/runs/4914554367?check_suite_focus=true 
Breaking change noted in https://github.com/markedjs/marked/releases/tag/v4.0.0