### PR TITLE
spec: make sure we get string keys in Record.fromEntries

### DIFF
--- a/spec/immutable-data-structures.html
+++ b/spec/immutable-data-structures.html
@@ -49,9 +49,8 @@
           1. Perform ? RequireObjectCoercible(_iterable_).
           1. Let _fields_ be a new empty List.
           1. Let _adder_ be a new Abstract Closure with parameters (_key_, _value_) that captures _fields_ and performs the following steps when called:
-            1. If Type(_key_) is Symbol, throw a *TypeError* exception.
             1. If Type(_value_) is Object, throw a *TypeError* exception.
-            1. Let _keyString_ be ? ToPropertyKey(_key_)
+            1. Let _keyString_ be ? ToString(_key_).
             1. Let _field_ be { [[Key]]: _keyString_, [[Value]]: _value_ }.
             1. Append _field_ to the end of list _fields_.
           1. Perform ! AddEntriesFromIterable(*undefined*, _iterable_, _adder_).

--- a/spec/immutable-data-structures.html
+++ b/spec/immutable-data-structures.html
@@ -53,7 +53,7 @@
             1. If Type(_value_) is Object, throw a *TypeError* exception.
             1. Let _field_ be { [[Key]]: _keyString_, [[Value]]: _value_ }.
             1. Append _field_ to the end of list _fields_.
-          1. Perform ! AddEntriesFromIterable(*undefined*, _iterable_, _adder_).
+          1. Perform ? AddEntriesFromIterable(*undefined*, _iterable_, _adder_).
           1. Return ! CreateRecord(_fields_).
         </emu-alg>
         <emu-note>

--- a/spec/immutable-data-structures.html
+++ b/spec/immutable-data-structures.html
@@ -49,8 +49,8 @@
           1. Perform ? RequireObjectCoercible(_iterable_).
           1. Let _fields_ be a new empty List.
           1. Let _adder_ be a new Abstract Closure with parameters (_key_, _value_) that captures _fields_ and performs the following steps when called:
-            1. If Type(_value_) is Object, throw a *TypeError* exception.
             1. Let _keyString_ be ? ToString(_key_).
+            1. If Type(_value_) is Object, throw a *TypeError* exception.
             1. Let _field_ be { [[Key]]: _keyString_, [[Value]]: _value_ }.
             1. Append _field_ to the end of list _fields_.
           1. Perform ! AddEntriesFromIterable(*undefined*, _iterable_, _adder_).

--- a/spec/immutable-data-structures.html
+++ b/spec/immutable-data-structures.html
@@ -51,7 +51,7 @@
           1. Let _adder_ be a new Abstract Closure with parameters (_key_, _value_) that captures _fields_ and performs the following steps when called:
             1. If Type(_key_) is Symbol, throw a *TypeError* exception.
             1. If Type(_value_) is Object, throw a *TypeError* exception.
-            1. Let _keyString_ be ? ToString(_key_)
+            1. Let _keyString_ be ? ToPropertyKey(_key_)
             1. Let _field_ be { [[Key]]: _keyString_, [[Value]]: _value_ }.
             1. Append _field_ to the end of list _fields_.
           1. Perform ! AddEntriesFromIterable(*undefined*, _iterable_, _adder_).

--- a/spec/immutable-data-structures.html
+++ b/spec/immutable-data-structures.html
@@ -49,8 +49,10 @@
           1. Perform ? RequireObjectCoercible(_iterable_).
           1. Let _fields_ be a new empty List.
           1. Let _adder_ be a new Abstract Closure with parameters (_key_, _value_) that captures _fields_ and performs the following steps when called:
+            1. If Type(_key_) is Symbol, throw a *TypeError* exception.
             1. If Type(_value_) is Object, throw a *TypeError* exception.
-            1. Let _field_ be { [[Key]]: _key_, [[Value]]: _value_ }.
+            1. Let _keyString_ be ? ToString(_key_)
+            1. Let _field_ be { [[Key]]: _keyString_, [[Value]]: _value_ }.
             1. Append _field_ to the end of list _fields_.
           1. Perform ! AddEntriesFromIterable(*undefined*, _iterable_, _adder_).
           1. Return ! CreateRecord(_fields_).


### PR DESCRIPTION
This coerces keys to strings like Object.fromEntries would do while rejecting symbols as they cannot be record keys