### PR TITLE
spec: make Record/Tuple exotic objects extensible

### DIFF
--- a/spec/ordinary-and-exotic-object-behaviours.html
+++ b/spec/ordinary-and-exotic-object-behaviours.html
@@ -21,7 +21,7 @@
           <dd>a Record exotic object</dd>
         </dl>
         <emu-alg>
-          1. Return *false*.
+          1. Return *true*.
         </emu-alg>
       </emu-clause>
 
@@ -201,7 +201,7 @@
         <h1>[[IsExtensible]] ()</h1>
         <p>When the [[IsExtensible]] internal method of a Tuple exotic object _T_ is called, the following steps are taken:</p>
         <emu-alg>
-          1. Return *false*.
+          1. Return *true*.
         </emu-alg>
       </emu-clause>
 


### PR DESCRIPTION
This change was discussed in a previous meeting and in older issues if not mistaken. We would make the exotic objects extensible (like other exotic primitive objects) but they should still be frozen.

Is that the correct understanding of the decision here? cc. @ljharb, @mhofman 