### PR TITLE
Disallow `#{ __proto__: something }`

### DIFF
--- a/spec/expression.html
+++ b/spec/expression.html
@@ -45,6 +45,19 @@
           `...` AssignmentExpression[+In, ?Yield, ?Await]
       </emu-grammar>
 
+      <emu-clause id="sec-record-initializer-static-semantics-early-errors">
+        <h1>Static Semantics: Early Errors</h1>
+        <emu-grammar>
+          RecordPropertyDefinition :
+            PropertyName `:` AssignmentExpression
+        </emu-grammar>
+        <ul>
+          <li>
+            It is a Syntax Error if PropName of |PropertyName| is *"__proto__"*.
+          </li>
+        </ul>
+      </emu-clause>
+
       <emu-clause id="sec-record-initializer-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
         <emu-grammar>RecordLiteral : `#{` `}`</emu-grammar>


### PR DESCRIPTION
`#{ __proto__ }` and `#{ ["__proto__"]: something }`  are still allowed, because when used in objects they don't set the object's prototype.

Fixes https://github.com/tc39/proposal-record-tuple/issues/313.