### PR TITLE
Implicit conversion of record to string throws TypeError

### DIFF
--- a/spec/abstract-operations.html
+++ b/spec/abstract-operations.html
@@ -416,7 +416,7 @@
               <ins>Record</ins>
             </td>
             <td>
-              <ins>Return ! RecordToString(_argument_).</ins>
+              <ins>Throw a *TypeError* exception.</ins>
             </td>
           </tr>
           <tr>

--- a/spec/fundamental-objects.html
+++ b/spec/fundamental-objects.html
@@ -39,3 +39,28 @@
     </emu-clause>
   </emu-clause>
 </emu-clause>
+<emu-clause id="sec-text-processing">
+  <h1>Text Processing</h1>
+
+  <emu-clause id="sec-string-objects">
+    <h1>String Objects</h1>
+
+    <emu-clause id="sec-string-constructor">
+      <h1>The String Constructor</h1>
+
+      <emu-clause id="sec-string-constructor-string-value">
+        <h1>String ( _value_ )</h1>
+        <p>When `String` is called with argument _value_, the following steps are taken:</p>
+        <emu-alg>
+          1. If _value_ is not present, let _s_ be the empty String.
+          1. Else,
+            1. If NewTarget is *undefined* and Type(_value_) is Symbol, return SymbolDescriptiveString(_value_).
+            1. <ins>If NewTarget is *undefined* and Type(_value_) is Record, return RecordToString(_value_).</ins>
+            1. Let _s_ be ? ToString(_value_).
+          1. If NewTarget is *undefined*, return _s_.
+          1. Return ! StringCreate(_s_, ? GetPrototypeFromConstructor(NewTarget, *"%String.prototype%"*)).
+        </emu-alg>
+      </emu-clause>
+    </emu-clause>
+  </emu-clause>
+</emu-clause>


### PR DESCRIPTION
Closes #289 

The current spec does not have a _useful_ ToString result for record: `"[object Record]"`. #136 

While the returned string is not useful it likely makes sense to also throw an error to catch accidental implicit conversion of a record to string:

```js
const rec = #{ prop: 42 };

// Explicit:
Object.prototype.toString.call(rec); // `[object Record]`
String(rec); // `[object Record]`
JSON.stringify(rec); // `{"prop":42}`
rec.toString(); // Throws "toString is not a function"

// Implicit:
`${rec)`; // Throws
"" + rec; // Throws
```

If the decision was made to change RecordToString to return a useful string then this PR would almost certainly be reverted.