### PR TITLE
change Tuple#concat to spread on IsArrayOrTuple, not IsConcatSpreadable

### DIFF
--- a/spec/immutable-data-structures.html
+++ b/spec/immutable-data-structures.html
@@ -256,7 +256,7 @@
           1. Let _items_ be a List whose first element is _T_ and whose subsequent element are, in left to right order, the arguments that were passed to this function invocation.
           1. Repeat, while _items_ is not empty,
             1. Remove the first element from _items_ and let _E_ be the value of the element.
-            1. Let _spreadable_ be ! IsArrayOrTuple(_E_).
+            1. Let _spreadable_ be ? IsArrayOrTuple(_E_).
             1. If _spreadable_ is *true*, then
               1. Let _k_ be 0.
               1. Let _len_ be ? LengthOfArrayLike(_E_).

--- a/spec/immutable-data-structures.html
+++ b/spec/immutable-data-structures.html
@@ -256,7 +256,7 @@
           1. Let _items_ be a List whose first element is _T_ and whose subsequent element are, in left to right order, the arguments that were passed to this function invocation.
           1. Repeat, while _items_ is not empty,
             1. Remove the first element from _items_ and let _E_ be the value of the element.
-            1. Let _spreadable_ be ? IsConcatSpreadable(_E_).
+            1. Let _spreadable_ be ! IsArrayOrTuple(_E_).
             1. If _spreadable_ is *true*, then
               1. Let _k_ be 0.
               1. Let _len_ be ? LengthOfArrayLike(_E_).


### PR DESCRIPTION
As discussed in today's plenary. Uses `IsArrayOrTuple` from #264.