### PR TITLE
fix ecmarkup syntax & pin biblio

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "https://tc39.github.io/ecma262/#sec-copyright-and-software-license",
       "dependencies": {
-        "@tc39/ecma262-biblio": "^2.1.2338",
+        "@tc39/ecma262-biblio": "2.1.2338",
         "browser-sync": "^2.26.7",
         "concurrently": "^5.2.0",
         "ecmarkup": "^13.0.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/tc39/proposal-record-tuple#readme",
   "dependencies": {
-    "@tc39/ecma262-biblio": "^2.1.2338",
+    "@tc39/ecma262-biblio": "2.1.2338",
     "browser-sync": "^2.26.7",
     "concurrently": "^5.2.0",
     "ecmarkup": "^13.0.1",

--- a/spec/abstract-operations.html
+++ b/spec/abstract-operations.html
@@ -857,7 +857,7 @@
       <h1>
         <ins>
           CreateRecord (
-            _entries_: a List of Records { [[Key]]: a String&comma; [[Value]]: an ECMAScript language value },
+            _entries_: a List of Records with fields [[Key]] (a String) and [[Value]] (an ECMAScript language value),
           )
         </ins>
       </h1>
@@ -875,7 +875,7 @@
       <h1>
         <ins>
           AddPropertyIntoRecordEntriesList (
-            _entries_: a List of Records { [[Key]]: a String&comma; [[Value]]: an ECMAScript language value },
+            _entries_: a List of Records with fields [[Key]] (a String) and [[Value]] (an ECMAScript language value),
             _propName_: a property key,
             _value_: an ECMAScript language value
           )


### PR DESCRIPTION
First commit fixes the syntax for Records in header types to match 262 (and to make ecmarkup happy).

Second commit pins the biblio, as is [recommended in its readme](https://www.npmjs.com/package/@tc39/ecma262-biblio).