### PR TITLE
Switch out `Record.isRecord` for `Record.recordValue`

### DIFF
--- a/NS-Proto-Appendix.md
+++ b/NS-Proto-Appendix.md
@@ -4,10 +4,6 @@
 
 Converts shallowly an object to a record. If the object has a non-const value, a TypeError will be thrown.
 
-## `Record.isRecord(value) -> boolean`
-
-Checks whether the parameter is either a Record primitive or Record wrapper.
-
 ## `Record.fromEntries(iterator: Iterator): Record`
 
 Similar to `Object.fromEntries`, but created a new `Record`.
@@ -27,15 +23,6 @@ Tuple.from(#[1, 2, 3]); // #[1, 2, 3]
 const set = new Set([1, 2, 3]);
 set.add(0);
 Tuple.from(set) // #[1, 2, 3, 0]
-```
-
-## `Tuple.isTuple(value) => boolean`
-
-Determines whether the passed value is a `Tuple`.
-
-```
-Tuple.isTuple(#[1, 2, 3]); // true
-Tuple.isTuple(#{ a: 1, b: 2 }); // false
 ```
 
 ## `Tuple.of(values...) => Tuple`

--- a/NS-Proto-Appendix.md
+++ b/NS-Proto-Appendix.md
@@ -8,6 +8,10 @@ Converts shallowly an object to a record. If the object has a non-const value, a
 
 Similar to `Object.fromEntries`, but created a new `Record`.
 
+## `Record.recordValue(rec: Record | Object): Record`
+
+Returns the primitive record value of the argument if the argument is already a Record or a Record Exotic Object, otherwise a TypeError will be thrown.
+
 # `Tuple` namespace
 
 ## `Tuple.from(arrayLike, mapFn, thisArg) => Tuple`

--- a/spec/immutable-data-structures.html
+++ b/spec/immutable-data-structures.html
@@ -60,15 +60,6 @@
           <p>The parameter _iterable_ is expected to be an object that implements an @@iterator method that returns an iterator object that produces a two element array-like object whose first element is a value that will be used as a Map key and whose second element is the value to associate with that key.</p>
         </emu-note>
       </emu-clause>
-      <emu-clause id="sec-record.isrecord">
-        <h1>Record.isRecord ( _arg_ )</h1>
-        <p>The *isRecord* function takes one argument _arg_, and performs the following steps:</p>
-        <emu-alg>
-          1. If Type(_arg_) is Record, return `true`.
-          1. If Type(_arg_) is Object and _arg_ has a [[RecordData]] internal slot, return `true`.
-          1. Return `false`.
-        </emu-alg>
-      </emu-clause>
       <emu-clause id="sec-record.prototype">
         <h1>Record.prototype</h1>
         <p>The initial value of *Record.prototype* is the value *null*.</p>
@@ -109,13 +100,6 @@
         <li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
         <li>has the following properties:</li>
       </ul>
-      <emu-clause id="sec-tuple.istuple">
-        <h1>Tuple.isTuple ( _arg_ )</h1>
-        <p>The *isTuple* function takes one argument _arg_, and performs the following steps:</p>
-        <emu-alg>
-          1. Return ! IsTuple(_arg_).
-        </emu-alg>
-      </emu-clause>
       <emu-clause id="sec-tuple.from">
         <h1>Tuple.from ( _items_ [ , _mapfn_ [ , _thisArg_ ] ] )</h1>
         <p>When the `from` method is called with argument _items_ and optional arguments _mapfn_ and _thisArg_, the following steps are taken:</p>

--- a/spec/immutable-data-structures.html
+++ b/spec/immutable-data-structures.html
@@ -60,6 +60,21 @@
           <p>The parameter _iterable_ is expected to be an object that implements an @@iterator method that returns an iterator object that produces a two element array-like object whose first element is a value that will be used as a Map key and whose second element is the value to associate with that key.</p>
         </emu-note>
       </emu-clause>
+      <emu-clause id="sec-record.recordValue">
+        <h1>Record.recordValue ( _arg_ )</h1>
+        <p>The *recordValue* function takes one argument _arg_, and performs the following steps:</p>
+        <emu-alg>
+          1. If Type(_arg_) is Record, return _arg_.
+          1. If Type(_arg_) is Object and _arg_ has a [[RecordData]] internal slot, then
+            1. Let _r_ be _value_.[[RecordData]].
+            1. Assert: Type(_r_) is Record.
+            1. Return _r_.
+          1. Throw a *TypeError* exception.
+        </emu-alg>
+        <emu-note>
+          <p>This static method is similar to the *valueOf* method that other primitves have on their prototype, <emu-xref href="#sec-tuple.prototype.valueof">Tuple.prototype.valueOf</emu-xref> for example. Because Records do not have a prototype the method is a static function on the constructor.</p>
+        </emu-note>
+      </emu-clause>
       <emu-clause id="sec-record.prototype">
         <h1>Record.prototype</h1>
         <p>The initial value of *Record.prototype* is the value *null*.</p>


### PR DESCRIPTION
Fixes #329 #333 #335

Removes `Record.isRecord` and `Tuple.isTuple`

Adds `Record.recordValue`

```js
Record.recordValue(#{}); // #{}
Record.recordValue(Object(#{})); // #{}

Record.recordValue({}); // TypeError
Record.recordValue(); // TypeError
```

