### PR TITLE
Record.fromEntries handles duplicate keys

### DIFF
--- a/spec/abstract-operations.html
+++ b/spec/abstract-operations.html
@@ -871,6 +871,29 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-deduplicaterecordentries" type="abstract operation">
+      <h1>
+        <ins>
+          DeduplicateRecordEntries (
+            _entries_: a List of Records with fields [[Key]] (a String) and [[Value]] (an ECMAScript language value),
+          )
+        </ins>
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It is used to creates a copy of _entries_ where only the last entry for each unique key is retained.</dd>
+      </dl>
+      <emu-alg>
+        1. Let _reversedEntries_ be _entries_ in reverse.
+        1. Let _uniqueEntries_ be an empty List.
+        1. For each element _kv_ in _reversedEntries_, do
+          1. Assert: Type(_kv_.[[Key]]) is String.
+          1. Assert: Type(_kv_.[[Value]]) is not Object.
+          1. If there is no entry _existing_ in _uniqueEntries_ such that _existing_.[[Key]] is _kv_.[[Key]], append _kv_ to _uniqueEntries_.
+        1. Return _uniqueEntries_.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-addpropertyintorecordentrieslist" type="abstract operation">
       <h1>
         <ins>

--- a/spec/expression.html
+++ b/spec/expression.html
@@ -72,12 +72,7 @@
         <emu-alg>
           1. Let _entries_ be an empty List.
           1. Perform ? RecordPropertyDefinitionEvaluation of |RecordPropertyDefinitionList| with argument _entries_.
-          1. Let _reversedEntries_ be _entries_ in reverse.
-          1. Let _uniqueEntries_ be an empty List.
-          1. For each element _kv_ in _reversedEntries_, do
-            1. Assert: Type(_kv_.[[Key]]) is String.
-            1. Assert: Type(_kv_.[[Value]]) is not Object.
-            1. If there is no entry _existing_ in _uniqueEntries_ such that _existing_.[[Key]] is _kv_.[[Key]], append _kv_ to _uniqueEntries_.
+          1. Let _uniqueEntries_ be DeduplicateRecordEntries(_entries_).
           1. Return ! CreateRecord(_uniqueEntries_).
         </emu-alg>
       </emu-clause>

--- a/spec/immutable-data-structures.html
+++ b/spec/immutable-data-structures.html
@@ -54,7 +54,8 @@
             1. Let _field_ be { [[Key]]: _keyString_, [[Value]]: _value_ }.
             1. Append _field_ to the end of list _fields_.
           1. Perform ? AddEntriesFromIterable(*undefined*, _iterable_, _adder_).
-          1. Return ! CreateRecord(_fields_).
+          1. Let _uniqueEntries_ be DeduplicateRecordEntries(_fields_).
+          1. Return ! CreateRecord(_uniqueEntries_).
         </emu-alg>
         <emu-note>
           <p>The parameter _iterable_ is expected to be an object that implements an @@iterator method that returns an iterator object that produces a two element array-like object whose first element is a value that will be used as a Map key and whose second element is the value to associate with that key.</p>


### PR DESCRIPTION
Fixes #339 

Moves the logic for handling duplicate keys into a new AO so can be re-used in the two places we need to handle duplicates.
Originally I inlined the logic directly into `createRecord` but decided a new AO only where its needed would put less work on engine authors to work out when they could skip the extra list processing.