### PR TITLE
refactors record define own property

### DIFF
--- a/spec/ordinary-and-exotic-object-behaviours.html
+++ b/spec/ordinary-and-exotic-object-behaviours.html
@@ -33,10 +33,7 @@
         </dl>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
-          1. If Type(_P_) is a Symbol, return *undefined*.
-          1. Let _getResult_ be ! RecordGet(_R_, _P_).
-          1. If _getResult_ is ~empty~, return *undefined*.
-          1. Return the PropertyDescriptor { [[Value]]: _getResult_, [[Writable]]: *false*, [[Enumerable]]: *true*, [[Configurable]]: *false* }.
+          1. Return ! RecordGetOwnProperty(_R_, _P_).
         </emu-alg>
       </emu-clause>
 
@@ -49,14 +46,9 @@
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
           1. If Type(_P_) is a Symbol, return *false*.
-          1. If _Desc_.[[Writable]] is present and has value *true*, return *false*.
-          1. If _Desc_.[[Enumerable]] is present and has value *false*, return *false*.
-          1. If _Desc_.[[Configurable]] is present and has value *true*, return *false*.
           1. If IsAccessorDescriptor(_Desc_) is *true*, return *false*.
-          1. Let _current_ be ! RecordGet(_R_, _P_).
-          1. If _current_ is ~empty~ return *false*.
-          1. If _Desc_.[[Value]] is present, return ! SameValue(_Desc_.[[Value]], _current_).
-          1. Return *true*.
+          1. Let _current_ be ! RecordGetOwnProperty(_R_, _P_).
+          1. Return IsCompatiblePropertyDescriptor (*false*, _Desc_, _current_).
         </emu-alg>
       </emu-clause>
 
@@ -190,6 +182,24 @@
             1. Assert: Type(_val_) is not Object.
             1. If _key_ is _P_, return _val_.
           1. Return ~empty~.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-recordgetownproperty-r-p" type="abstract operation">
+        <h1>
+          <ins>
+            RecordGetOwnProperty (
+              _R_: a Record,
+              _P_: a PropertyKey
+            )
+          </ins>
+        </h1>
+        <dl class="header"></dl>
+        <emu-alg>
+          1. If Type(_P_) is a Symbol, return *undefined*.
+          1. Let _getResult_ be ! RecordGet(_R_, _P_).
+          1. If _getResult_ is ~empty~, return *undefined*.
+          1. Return the PropertyDescriptor { [[Value]]: _getResult_, [[Writable]]: *false*, [[Enumerable]]: *true*, [[Configurable]]: *false* }.
         </emu-alg>
       </emu-clause>
     </emu-clause>

--- a/spec/ordinary-and-exotic-object-behaviours.html
+++ b/spec/ordinary-and-exotic-object-behaviours.html
@@ -48,7 +48,7 @@
           1. If Type(_P_) is a Symbol, return *false*.
           1. If IsAccessorDescriptor(_Desc_) is *true*, return *false*.
           1. Let _current_ be ! RecordGetOwnProperty(_R_, _P_).
-          1. Return IsCompatiblePropertyDescriptor (*false*, _Desc_, _current_).
+          1. Return IsCompatiblePropertyDescriptor(*false*, _Desc_, _current_).
         </emu-alg>
       </emu-clause>
 
@@ -190,7 +190,7 @@
           <ins>
             RecordGetOwnProperty (
               _R_: a Record,
-              _P_: a PropertyKey
+              _P_: a property key,
             )
           </ins>
         </h1>
@@ -199,7 +199,7 @@
           1. If Type(_P_) is a Symbol, return *undefined*.
           1. Let _getResult_ be ! RecordGet(_R_, _P_).
           1. If _getResult_ is ~empty~, return *undefined*.
-          1. Return the PropertyDescriptor { [[Value]]: _getResult_, [[Writable]]: *false*, [[Enumerable]]: *true*, [[Configurable]]: *false* }.
+          1. Return the Property Descriptor { [[Value]]: _getResult_, [[Writable]]: *false*, [[Enumerable]]: *true*, [[Configurable]]: *false* }.
         </emu-alg>
       </emu-clause>
     </emu-clause>

--- a/spec/ordinary-and-exotic-object-behaviours.html
+++ b/spec/ordinary-and-exotic-object-behaviours.html
@@ -48,6 +48,7 @@
           1. If Type(_P_) is a Symbol, return *false*.
           1. If IsAccessorDescriptor(_Desc_) is *true*, return *false*.
           1. Let _current_ be ! RecordGetOwnProperty(_R_, _P_).
+          1. If _current_ is *undefined*, return *false*.
           1. Return IsCompatiblePropertyDescriptor(*false*, _Desc_, _current_).
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
PR based on suggestions from @anba and @ljharb in #343 

**Pro**: This approach reuses [validateandapplypropertydescriptor](https://tc39.es/ecma262/#sec-validateandapplypropertydescriptor) logic rather than reimplementing it.

**Con**: Less clear to implementers how to implement this in the least number of steps (if they wanted to optimize this operation)