### PR TITLE
[spec] Records and Tuples have a useful toString

### DIFF
--- a/spec/abstract-operations.html
+++ b/spec/abstract-operations.html
@@ -957,6 +957,28 @@
     </emu-clause>
   </emu-clause>
 
+    <emu-clause id="sec-listjoin" type="abstract operation">
+      <h1>
+        <ins>
+          ListJoin (
+            _list_: a List of Strings,
+          ): a String
+        </ins>
+      </h1>
+      <dl class="header"></dl>
+      <emu-alg>
+        1. Let _ret_ be *""*.
+        1. Let _len_ be the length of _list_.
+        1. Let _k_ be 0.
+        1. Repeat, while _k_ &lt; _len_,
+          1. Let _s_ be _list_[_k_].
+          1. Set _ret_ to be the string-concatenation of _ret_ and _s_.
+          1. Set _k_ to _k_ + 1.
+          1. If _k_ &lt; _len_, Set _ret_ to be the string-concatenation of _ret_ and *", "*.
+        1. Return _ret_.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-isconcatspreadable" type="abstract operation">
       <h1>
         IsConcatSpreadable (

--- a/spec/abstract-operations.html
+++ b/spec/abstract-operations.html
@@ -446,7 +446,7 @@
               <ins>Record</ins>
             </td>
             <td>
-              <ins>Throw a *TypeError* exception.</ins>
+              <ins>Return RecordToString(_argument_).</ins>
             </td>
           </tr>
           <tr>
@@ -454,7 +454,7 @@
               <ins>Tuple</ins>
             </td>
             <td>
-              <ins>Return ? TupleToString(_argument_).</ins>
+              <ins>Return TupleToString(_argument_).</ins>
             </td>
           </tr>
           <tr>

--- a/spec/abstract-operations.html
+++ b/spec/abstract-operations.html
@@ -974,7 +974,7 @@
           1. Let _s_ be _list_[_k_].
           1. Set _ret_ to be the string-concatenation of _ret_ and _s_.
           1. Set _k_ to _k_ + 1.
-          1. If _k_ &lt; _len_, Set _ret_ to be the string-concatenation of _ret_ and *", "*.
+          1. If _k_ &lt; _len_, set _ret_ to be the string-concatenation of _ret_ and *", "*.
         1. Return _ret_.
       </emu-alg>
     </emu-clause>

--- a/spec/abstract-operations.html
+++ b/spec/abstract-operations.html
@@ -581,6 +581,26 @@
     </emu-clause>
   </emu-clause>
 
+  <emu-clause id="sec-topropertykey" type="abstract operation">
+    <h1>
+      ToPropertyKey (
+        _argument_: unknown,
+      ): either a normal completion containing a property key or a throw completion
+    </h1>
+    <dl class="header">
+      <dt>description</dt>
+      <dd>It converts _argument_ to a value that can be used as a property key.</dd>
+    </dl>
+    <emu-alg>
+      1. Let _key_ be ? ToPrimitive(_argument_, ~string~).
+      1. If _key_ is a Symbol, then
+        1. Return _key_.
+      1. <ins>If _key_ is a Record or _key_ is a Tuple, then</ins>
+        1. <ins>Throw a *TypeError* exception.</ins>
+      1. Return ! ToString(_key_).
+    </emu-alg>
+  </emu-clause>
+
   <emu-clause id="sec-testing-and-comparison-operations">
     <h1>Testing and Comparison Operations</h1>
 

--- a/spec/data-types-and-values.html
+++ b/spec/data-types-and-values.html
@@ -29,23 +29,28 @@
               1. Let _kvString_ be QuoteJSONString(_key_).
               1. Set _kvString_ to be the string-concatenation of _kvString_ and *": "*.
               1. Let _value_ be _kv_.[[Value]].
-              1. If _value_ is a Symbol, Let _valueString_ be SymbolDescriptiveString(_value_).
-              1. Else if _value_ is a String, Let _valueString_ by QuoteJSONString(_value_).
-              1. Else, Let _valueString_ be ! ToString(_value_).
-              1. Set _kvString_ to be the string-concatenation of _kvString_ and _valueString_.
+              1. Set _kvString_ to be the string-concatenation of _kvString_ and StringifyRecordValue(_value_).
               1. Append _kvString_ to the end of _strings_.
-            1. Let _len_ be the length of List _strings_.
-            1. Let _ret_ be the value *"#{"*.
-            1. Let _k_ be 0.
-            1. Repeat, while _k_ &lt; _len_,
-              1. Let _string_ be _strings_[_k_].
-              1. Set _ret_ to be the string-concatenation of _ret_ and *" "*.
-              1. Set _ret_ to be the string-concatenation of _ret_ and _string_.
-              1. Set _k_ to _k_ + 1.
-              1. If _k_ &lt; _len_, Set _ret_ to be the string-concatenation of _ret_ and *","*.
-              1. Set _ret_ to be the string-concatenation of _ret_ and *" "*.
-            1. Set _ret_ to be the string-concatenation of _ret_ and *"}"*.
+            1. Let _ret_ be *"#{ "*.
+            1. Set _ret_ to be the string-concatenation of _ret_ and ListJoin(_strings_).
+            1. Set _ret_ to be the string-concatenation of _ret_ and *" }"*.
             1. Return _ret_.
+        </emu-alg>
+      </emu-clause>
+
+      <emu-clause id="sec-immutable-types-stringify-record-value" type="abstract operation">
+        <h1>
+          <ins>
+            StringifyRecordValue (
+              _value_: an ECMAScript language value, but not an Object,
+            ): a String
+          </ins>
+        </h1>
+        <dl class="header"></dl>
+        <emu-alg>
+          1. If _value_ is a Symbol, Return SymbolDescriptiveString(_value_).
+          1. Else if _value_ is a String, Return QuoteJSONString(_value_).
+          1. Else, Return ! ToString(_value_).
         </emu-alg>
       </emu-clause>
 
@@ -133,18 +138,10 @@
             1. Assert: _list_ is a List of ECMAscript language values.
             1. Let _strings_ be a new empty List.
             1. For each element _value_ of _list_, do
-              1. If _value_ is a Symbol, Let _valueString_ be SymbolDescriptiveString(_value_).
-              1. Else if _value_ is a String, Let _valueString_ by QuoteJSONString(_value_).
-              1. Else, Let _valueString_ be ! ToString(_value_).
+              1. Let _valueString_ be StringifyRecordValue(_value_).
               1. Append _valueString_ to the end of _strings_.
-            1. Let _len_ be the length of _strings_.
             1. Let _ret_ be *"#["*.
-            1. Let _k_ be 0.
-            1. Repeat, while _k_ &lt; _len_,
-              1. Let _string_ be _strings_[_k_].
-              1. Set _ret_ to be the string-concatenation of _ret_ and _string_.
-              1. Set _k_ to _k_ + 1.
-              1. If _k_ &lt; _len_, Set _ret_ to be the string-concatenation of _ret_ and *", "*.
+            1. Set _ret_ to be the string-concatenation of _ret_ and ListJoin(_strings_).
             1. Set _ret_ to be the string-concatenation of _ret_ and *"]"*.
             1. Return _ret_.
         </emu-alg>

--- a/spec/data-types-and-values.html
+++ b/spec/data-types-and-values.html
@@ -31,10 +31,7 @@
               1. Let _value_ be _kv_.[[Value]].
               1. Set _kvString_ to be the string-concatenation of _kvString_ and StringifyRecordValue(_value_).
               1. Append _kvString_ to the end of _strings_.
-            1. Let _ret_ be *"#{ "*.
-            1. Set _ret_ to be the string-concatenation of _ret_ and ListJoin(_strings_).
-            1. Set _ret_ to be the string-concatenation of _ret_ and *" }"*.
-            1. Return _ret_.
+            1. Return the string-concatenation of *"#{ "*, ListJoin(_strings_), and *" }"*.
         </emu-alg>
       </emu-clause>
 
@@ -42,7 +39,7 @@
         <h1>
           <ins>
             StringifyRecordValue (
-              _value_: an ECMAScript language value, but not an Object,
+              _value_: a primitive value,
             ): a String
           </ins>
         </h1>
@@ -135,15 +132,12 @@
         </dl>
         <emu-alg>
             1. Let _list_ be _argument_.[[Sequence]].
-            1. Assert: _list_ is a List of ECMAscript language values.
+            1. Assert: _list_ is a List of ECMAScript language values.
             1. Let _strings_ be a new empty List.
             1. For each element _value_ of _list_, do
               1. Let _valueString_ be StringifyRecordValue(_value_).
               1. Append _valueString_ to the end of _strings_.
-            1. Let _ret_ be *"#["*.
-            1. Set _ret_ to be the string-concatenation of _ret_ and ListJoin(_strings_).
-            1. Set _ret_ to be the string-concatenation of _ret_ and *"]"*.
-            1. Return _ret_.
+            1. Return the string-concatenation of *"#["*, ListJoin(_strings_), and *"]"*.
         </emu-alg>
       </emu-clause>
 

--- a/spec/data-types-and-values.html
+++ b/spec/data-types-and-values.html
@@ -22,7 +22,26 @@
           <dd>It converts _argument_ to a String.</dd>
         </dl>
         <emu-alg>
-            1. Return *"[object Record]"*.
+            1. Let _list_ be _argument_.[[Fields]].
+            1. Let _length_ be the length of List _list_.
+            1. Let _ret_ be the value *"#{"*.
+            1. Let _k_ be 0.
+            1. Repeat, while _k_ &lt; _len_,
+              1. Let _entry_ be _list_[_k_].
+              1. Let _key_ be _entry_.[[Key]].
+              1. Let _value_ be _entry_.[[Value]].
+              1. If _value_ is a Symbol, Let _valueString_ be SymbolDescriptiveString(_value_).
+              1. Else if _value_ is a String, Let _valueString_ by QuoteJSONString(_value_).
+              1. Else, Let _valueString_ be ! ToString(_value_).
+              1. Set _ret_ to be the string-concatenation _ret_ and *" "*.
+              1. Set _ret_ to be the string-concatenation _ret_ and QuoteJSONString(_key_).
+              1. Set _ret_ to be the string-concatenation _ret_ and *": "*.
+              1. Set _ret_ to be the string-concatenation _ret_ and _valueString_.
+              1. If _k_ = _len_ - 1, Set _ret_ to be the string-concatenation _ret_ and *" "*.
+              1. Else, Set _ret_ to be the string-concatenation _ret_ and *", "*.
+              1. Set _k_ to _k_ + 1.
+            1. Set _ret_ to be the string-concatenation _ret_ and *"}"*.
+            1. Return _ret_.
         </emu-alg>
       </emu-clause>
 
@@ -98,12 +117,28 @@
           <ins>
             TupleToString (
               _argument_: a Tuple,
-            ): either a normal completion containing an ECMAScript language value, or an abrupt completion
+            ): a String
           </ins>
         </h1>
-        <dl class="header"></dl>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It converts _argument_ to a String.</dd>
+        </dl>
         <emu-alg>
-            1. Return ? Call(%Array.prototype.join%, _argument_, &laquo; &raquo;).
+            1. Let _list_ be _argument_.[[Sequence]].
+            1. Let _length_ be the length of List _list_.
+            1. Let _ret_ be the value *"#["*.
+            1. Let _k_ be 0.
+            1. Repeat, while _k_ &lt; _len_,
+              1. Let _value_ be _list_[_k_].
+              1. If _value_ is a Symbol, Let _valueString_ be SymbolDescriptiveString(_value_).
+              1. Else if _value_ is a String, Let _valueString_ by QuoteJSONString(_value_).
+              1. Else, Let _valueString_ be ! ToString(_value_).
+              1. Set _ret_ to be the string-concatenation _ret_ and _valueString_.
+              1. If _k_ &lt; _len_, Set _ret_ to be the string-concatenation _ret_ and *", "*.
+              1. Set _k_ to _k_ + 1.
+            1. Set _ret_ to be the string-concatenation _ret_ and *"]"*.
+            1. Return _ret_.
         </emu-alg>
       </emu-clause>
 

--- a/spec/data-types-and-values.html
+++ b/spec/data-types-and-values.html
@@ -127,17 +127,20 @@
         <emu-alg>
             1. Let _list_ be _argument_.[[Sequence]].
             1. Assert: _list_ is a List of ECMAscript language values.
-            1. Let _length_ be the length of _list_.
-            1. Let _ret_ be *"#["*.
-            1. Let _k_ be 0.
-            1. Repeat, while _k_ &lt; _len_,
-              1. Let _value_ be _list_[_k_].
+            1. Let _strings_ be a new empty List.
+            1. For each element _value_ of _list_, do
               1. If _value_ is a Symbol, Let _valueString_ be SymbolDescriptiveString(_value_).
               1. Else if _value_ is a String, Let _valueString_ by QuoteJSONString(_value_).
               1. Else, Let _valueString_ be ! ToString(_value_).
-              1. Set _ret_ to be the string-concatenation of _ret_ and _valueString_.
-              1. If _k_ &lt; _len_, Set _ret_ to be the string-concatenation of _ret_ and *", "*.
+              1. Append _valueString_ to the end of _strings_.
+            1. Let _len_ be the length of _strings_.
+            1. Let _ret_ be *"#["*.
+            1. Let _k_ be 0.
+            1. Repeat, while _k_ &lt; _len_,
+              1. Let _string_ be _strings_[_k_].
+              1. Set _ret_ to be the string-concatenation of _ret_ and _string_.
               1. Set _k_ to _k_ + 1.
+              1. If _k_ &lt; _len_, Set _ret_ to be the string-concatenation of _ret_ and *", "*.
             1. Set _ret_ to be the string-concatenation of _ret_ and *"]"*.
             1. Return _ret_.
         </emu-alg>

--- a/spec/data-types-and-values.html
+++ b/spec/data-types-and-values.html
@@ -7,7 +7,7 @@
 
     <emu-clause number="8" id="sec-ecmascript-language-types-record-type">
       <h1>The Record Type</h1>
-      <p>The Record type is the set of all finite mappings from Strings to ECMAScript primitive values including Record and Tuple. Each record value holds an associated [[Fields]] List value which is a list of pairs of the form { [[Key]], [[Value]] } where the [[Key]] is a String and [[Value]] is any primitive value. Entries of [[Fields]] are sorted by [[Key]] in ascending code unit order. The [[Fields]] List and its entries are never modified.</p>
+      <p>The <dfn variants="is a Record,is not a Record">Record type</dfn> is the set of all finite mappings from Strings to ECMAScript primitive values including Record and Tuple. Each record value holds an associated [[Fields]] List value which is a list of pairs of the form { [[Key]], [[Value]] } where the [[Key]] is a String and [[Value]] is any primitive value. Entries of [[Fields]] are sorted by [[Key]] in ascending code unit order. The [[Fields]] List and its entries are never modified.</p>
 
       <emu-clause id="sec-immutable-types-record-tostring" type="abstract operation">
         <h1>
@@ -116,7 +116,7 @@
 
     <emu-clause id="sec-ecmascript-language-types-tuple-type">
       <h1>The Tuple Type</h1>
-      <p>The Tuple type is the set of all finite and ordered sequences of ECMAScript primitive values including Record and Tuple. Each tuple value holds an associated [[Sequence]] List which is a list of primitive values. The [[Sequence]] List is integer-indexed. The [[Sequence]] List and its values are never modified.</p>
+      <p>The <dfn variants="is a Tuple,is not a Tuple">Tuple type</dfn> is the set of all finite and ordered sequences of ECMAScript primitive values including Record and Tuple. Each tuple value holds an associated [[Sequence]] List which is a list of primitive values. The [[Sequence]] List is integer-indexed. The [[Sequence]] List and its values are never modified.</p>
 
       <emu-clause id="sec-immutable-types-tuple-tostring" type="abstract operation">
         <h1>

--- a/spec/data-types-and-values.html
+++ b/spec/data-types-and-values.html
@@ -23,23 +23,27 @@
         </dl>
         <emu-alg>
             1. Let _list_ be _argument_.[[Fields]].
-            1. Let _length_ be the length of List _list_.
-            1. Let _ret_ be the value *"#{"*.
-            1. Let _k_ be 0.
-            1. Repeat, while _k_ &lt; _len_,
-              1. Let _entry_ be _list_[_k_].
-              1. Let _key_ be _entry_.[[Key]].
-              1. Let _value_ be _entry_.[[Value]].
+            1. Let _strings_ be a new empty List.
+            1. For each Record { [[Key]], [[Value]] } _kv_ of _list_, do
+              1. Let _key_ be _kv_.[[Key]].
+              1. Let _kvString_ be QuoteJSONString(_key_).
+              1. Set _kvString_ to be the string-concatenation of _kvString_ and *": "*.
+              1. Let _value_ be _kv_.[[Value]].
               1. If _value_ is a Symbol, Let _valueString_ be SymbolDescriptiveString(_value_).
               1. Else if _value_ is a String, Let _valueString_ by QuoteJSONString(_value_).
               1. Else, Let _valueString_ be ! ToString(_value_).
-              1. Set _ret_ to be the string-concatenation _ret_ and *" "*.
-              1. Set _ret_ to be the string-concatenation _ret_ and QuoteJSONString(_key_).
-              1. Set _ret_ to be the string-concatenation _ret_ and *": "*.
-              1. Set _ret_ to be the string-concatenation _ret_ and _valueString_.
-              1. If _k_ = _len_ - 1, Set _ret_ to be the string-concatenation of _ret_ and *" "*.
-              1. Else, set _ret_ to be the string-concatenation of _ret_ and *", "*.
+              1. Set _kvString_ to be the string-concatenation of _kvString_ and _valueString_.
+              1. Append _kvString_ to the end of _strings_.
+            1. Let _len_ be the length of List _strings_.
+            1. Let _ret_ be the value *"#{"*.
+            1. Let _k_ be 0.
+            1. Repeat, while _k_ &lt; _len_,
+              1. Let _string_ be _strings_[_k_].
+              1. Set _ret_ to be the string-concatenation of _ret_ and *" "*.
+              1. Set _ret_ to be the string-concatenation of _ret_ and _string_.
               1. Set _k_ to _k_ + 1.
+              1. If _k_ &lt; _len_, Set _ret_ to be the string-concatenation of _ret_ and *","*.
+              1. Set _ret_ to be the string-concatenation of _ret_ and *" "*.
             1. Set _ret_ to be the string-concatenation of _ret_ and *"}"*.
             1. Return _ret_.
         </emu-alg>

--- a/spec/data-types-and-values.html
+++ b/spec/data-types-and-values.html
@@ -37,10 +37,10 @@
               1. Set _ret_ to be the string-concatenation _ret_ and QuoteJSONString(_key_).
               1. Set _ret_ to be the string-concatenation _ret_ and *": "*.
               1. Set _ret_ to be the string-concatenation _ret_ and _valueString_.
-              1. If _k_ = _len_ - 1, Set _ret_ to be the string-concatenation _ret_ and *" "*.
-              1. Else, Set _ret_ to be the string-concatenation _ret_ and *", "*.
+              1. If _k_ = _len_ - 1, Set _ret_ to be the string-concatenation of _ret_ and *" "*.
+              1. Else, set _ret_ to be the string-concatenation of _ret_ and *", "*.
               1. Set _k_ to _k_ + 1.
-            1. Set _ret_ to be the string-concatenation _ret_ and *"}"*.
+            1. Set _ret_ to be the string-concatenation of _ret_ and *"}"*.
             1. Return _ret_.
         </emu-alg>
       </emu-clause>
@@ -126,18 +126,19 @@
         </dl>
         <emu-alg>
             1. Let _list_ be _argument_.[[Sequence]].
-            1. Let _length_ be the length of List _list_.
-            1. Let _ret_ be the value *"#["*.
+            1. Assert: _list_ is a List of ECMAscript language values.
+            1. Let _length_ be the length of _list_.
+            1. Let _ret_ be *"#["*.
             1. Let _k_ be 0.
             1. Repeat, while _k_ &lt; _len_,
               1. Let _value_ be _list_[_k_].
               1. If _value_ is a Symbol, Let _valueString_ be SymbolDescriptiveString(_value_).
               1. Else if _value_ is a String, Let _valueString_ by QuoteJSONString(_value_).
               1. Else, Let _valueString_ be ! ToString(_value_).
-              1. Set _ret_ to be the string-concatenation _ret_ and _valueString_.
-              1. If _k_ &lt; _len_, Set _ret_ to be the string-concatenation _ret_ and *", "*.
+              1. Set _ret_ to be the string-concatenation of _ret_ and _valueString_.
+              1. If _k_ &lt; _len_, Set _ret_ to be the string-concatenation of _ret_ and *", "*.
               1. Set _k_ to _k_ + 1.
-            1. Set _ret_ to be the string-concatenation _ret_ and *"]"*.
+            1. Set _ret_ to be the string-concatenation of _ret_ and *"]"*.
             1. Return _ret_.
         </emu-alg>
       </emu-clause>

--- a/spec/data-types-and-values.html
+++ b/spec/data-types-and-values.html
@@ -47,7 +47,7 @@
         <emu-alg>
           1. If _value_ is a Symbol, Return SymbolDescriptiveString(_value_).
           1. Else if _value_ is a String, Return QuoteJSONString(_value_).
-          1. Else, Return ! ToString(_value_).
+          1. Else, return ! ToString(_value_).
         </emu-alg>
       </emu-clause>
 

--- a/spec/immutable-data-structures.html
+++ b/spec/immutable-data-structures.html
@@ -466,10 +466,15 @@
         <p>`Tuple.prototype.toLocaleString` is a distinct function that implements the same algorithm as `Array.prototype.toLocaleString` as defined in <emu-xref href="#sec-array.prototype.tolocalestring"></emu-xref> except that ? thisTupleValue(*this* value) is used instead of directly accessing the *this* value. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse, do not change, and their access is not observable. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
         <p>This function is not generic, since thisTupleValue(*this* value) can return an abrupt completion: in that case, that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
-      <emu-clause id="sec-tuple.prototype.tostring">
+      <emu-clause id="sec-tuple.prototype.toString">
         <h1>Tuple.prototype.toString ( )</h1>
-        <p>`Tuple.prototype.toString` is a distinct function that implements the same algorithm as `Array.prototype.toString` as defined in <emu-xref href="#sec-array.prototype.tostring"></emu-xref> except that ? thisTupleValue(*this* value) is used instead of directly accessing the *this* value. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse, do not change, and their access is not observable. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
-        <p>This function is not generic, since thisTupleValue(*this* value) can return an abrupt completion: in that case, that exception is thrown instead of evaluating the algorithm.</p>
+
+        <p>When the *toString* method is called, the following steps are taken:</p>
+
+        <emu-alg>
+          1. Let _tuple_ be ? thisTupleValue(*this* value).
+          1. Return TupleToString(_tuple_).
+        </emu-alg>
       </emu-clause>
       <emu-clause id="sec-tuple.prototype.values">
         <h1>Tuple.prototype.values ( )</h1>

--- a/spec/immutable-data-structures.html
+++ b/spec/immutable-data-structures.html
@@ -466,7 +466,7 @@
         <p>`Tuple.prototype.toLocaleString` is a distinct function that implements the same algorithm as `Array.prototype.toLocaleString` as defined in <emu-xref href="#sec-array.prototype.tolocalestring"></emu-xref> except that ? thisTupleValue(*this* value) is used instead of directly accessing the *this* value. The implementation of the algorithm may be optimized with the knowledge that the *this* value is an object that has a fixed length and whose <emu-xref href="#integer-index">integer-indexed</emu-xref> properties are not sparse, do not change, and their access is not observable. However, such optimization must not introduce any observable changes in the specified behaviour of the algorithm.</p>
         <p>This function is not generic, since thisTupleValue(*this* value) can return an abrupt completion: in that case, that exception is thrown instead of evaluating the algorithm.</p>
       </emu-clause>
-      <emu-clause id="sec-tuple.prototype.toString">
+      <emu-clause id="sec-tuple.prototype.tostring">
         <h1>Tuple.prototype.toString ( )</h1>
 
         <p>When the *toString* method is called, the following steps are taken:</p>


### PR DESCRIPTION
Implements a _useful_ `toString` for records and tuples.  Heavily based on @rickbutton 's [previous branch](https://github.com/tc39/proposal-record-tuple/commits/rb/useful-tostring).

```javascript
#[Symbol("s"), 99999n, #{ a: undefined, "\n": "s\"" } ].toString()
// `#[Symbol(s), 99999, #{ "a": undefined, "\n": "s\"" }]`
```

Fixes #136 